### PR TITLE
Fix: Correct behavior of 'expense-ongoing' checkbox

### DIFF
--- a/app.js
+++ b/app.js
@@ -1312,14 +1312,25 @@ document.addEventListener('DOMContentLoaded', () => {
         renderExpensesTable(); renderCashflowTable(); resetExpenseForm();
     });
     function resetExpenseForm() {
-        expenseForm.reset();
-        expenseOngoingCheckbox.checked = true; expenseEndDateInput.disabled = true; expenseEndDateInput.value = '';
-        expenseFrequencySelect.value = 'Único'; expenseIsRealCheckbox.checked = false;
+    expenseForm.reset(); // This might trigger a change event on expenseFrequencySelect if its value changes
+
+    // Set frequency to 'Único' first
+    expenseFrequencySelect.value = 'Único'; 
+
+    // Now, explicitly set the state for 'Único' frequency
+    expenseOngoingCheckbox.checked = false;
+    expenseOngoingCheckbox.disabled = true;
+    expenseEndDateInput.disabled = true; 
+    expenseEndDateInput.value = '';
+    expenseIsRealCheckbox.checked = false;
+
+    // ... (rest of the function, e.g., setting default category, button text, etc.)
         if (expenseCategorySelect.options.length > 0 && expenseCategorySelect.value === "") {
             if (expenseCategorySelect.options[0].value !== "") expenseCategorySelect.selectedIndex = 0;
             else if (expenseCategorySelect.options.length > 1) expenseCategorySelect.selectedIndex = 1;
         }
-        addExpenseButton.textContent = 'Agregar Gasto'; cancelEditExpenseButton.style.display = 'none';
+    addExpenseButton.textContent = 'Agregar Gasto'; 
+    cancelEditExpenseButton.style.display = 'none';
         editingExpenseIndex = null;
         expenseStartDateInput.value = getISODateString(currentBackupData && currentBackupData.analysis_start_date ? new Date(currentBackupData.analysis_start_date) : new Date());
         updateRemoveCategoryButtonState();
@@ -1877,4 +1888,7 @@ document.addEventListener('DOMContentLoaded', () => {
     updateAnalysisDurationLabel();
     // updateUsdClpInfoLabel(); // No longer needed here, called by activateTab or showMainContentScreen
     incomeReimbursementCategoryContainer.style.display = 'none';
-});
+
+    // Trigger change event on expense frequency select to apply initial state
+    expenseFrequencySelect.dispatchEvent(new Event('change')); 
+}); // This is the closing of DOMContentLoaded

--- a/index.html
+++ b/index.html
@@ -181,7 +181,7 @@
                             <label for="expense-end-date">Fecha Fin (si aplica):</label>
                             <input type="date" id="expense-end-date">
                              <div class="checkbox-container">
-                                <input type="checkbox" id="expense-ongoing" checked>
+                                <input type="checkbox" id="expense-ongoing">
                                 <label for="expense-ongoing">Gasto recurrente sin fin</label>
                             </div>
 


### PR DESCRIPTION
The 'expense-ongoing' (Gasto recurrente sin fin) checkbox in the expenses form was incorrectly enabled and checked by default when the frequency was set to 'Único' (Unique).

This commit addresses the issue by:
1. Modifying `resetExpenseForm()` in `app.js` to ensure that when the expense frequency is reset to 'Único', the `expenseOngoingCheckbox` is set to `false` (unchecked) and `disabled`.
2. Adjusting the initial state in `DOMContentLoaded` in `app.js` by triggering a 'change' event on `expenseFrequencySelect`. This ensures the checkbox is correctly configured on page load if 'Único' is the default frequency.
3. Removing the `checked` attribute from the `expense-ongoing` checkbox in `index.html` to allow JavaScript to fully control its initial state.

These changes ensure the checkbox is only enabled for recurring frequencies and behaves as expected during form initialization, reset, and frequency changes.