### PR TITLE
feat: Implement enhanced chart interactivity

### DIFF
--- a/app.js
+++ b/app.js
@@ -1972,7 +1972,51 @@ document.addEventListener('DOMContentLoaded', () => {
         cashflowChartInstance = new Chart(cashflowChartCanvas, {
             type: 'line',
             data: { labels: labels, datasets: [{ label: 'Saldo Final Estimado', data: endBalances, borderColor: 'rgba(54, 162, 235, 1)', backgroundColor: 'rgba(54, 162, 235, 0.2)', tension: 0.1, fill: false, pointRadius: 4, pointBackgroundColor: 'rgba(54, 162, 235, 1)', borderWidth: 2, order: 1, }, { label: 'Ingreso Total Neto', data: incomes, borderColor: 'rgba(75, 192, 192, 1)', backgroundColor: 'rgba(75, 192, 192, 1)', type: 'scatter', showLine: false, pointRadius: 6, pointStyle: 'circle', order: 2, }, { label: 'Gasto Total', data: totalExpenses.map(e => -e), borderColor: 'rgba(255, 99, 132, 1)', backgroundColor: 'rgba(255, 99, 132, 1)', type: 'scatter', showLine: false, pointRadius: 6, pointStyle: 'rectRot', order: 2, }, { label: 'Flujo Neto del Período', data: netFlows, borderColor: 'rgba(255, 206, 86, 1)', backgroundColor: 'rgba(255, 206, 86, 1)', type: 'scatter', showLine: false, pointRadius: 6, pointStyle: 'triangle', order: 2, }] },
-            options: { responsive: true, maintainAspectRatio: false, scales: { y: { type: 'linear', display: true, position: 'left', title: { display: true, text: `Saldo / Flujos (${currentBackupData.display_currency_symbol || '$'})` } } }, plugins: { tooltip: { callbacks: { label: function (context) { let label = context.dataset.label || ''; if (label) label += ': '; if (context.parsed.y !== null) label += formatCurrencyJS(context.parsed.y, currentBackupData.display_currency_symbol || '$'); return label; } } }, legend: { position: 'top' } } }
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: {
+                    y: {
+                        type: 'linear',
+                        display: true,
+                        position: 'left',
+                        title: { display: true, text: `Saldo / Flujos (${currentBackupData.display_currency_symbol || '$'})` }
+                    }
+                },
+                plugins: {
+                    tooltip: {
+                        callbacks: {
+                            label: function (context) {
+                                let label = context.dataset.label || '';
+                                if (label) label += ': ';
+                                if (context.parsed.y !== null) label += formatCurrencyJS(context.parsed.y, currentBackupData.display_currency_symbol || '$');
+                                return label;
+                            }
+                        }
+                    },
+                    legend: { position: 'top' },
+                    zoom: {
+                        pan: {
+                            enabled: true,
+                            mode: 'xy',
+                            modifierKey: 'ctrl',
+                        },
+                        zoom: {
+                            wheel: {
+                                enabled: true,
+                            },
+                            pinch: {
+                                enabled: true
+                            },
+                            drag: {
+                                enabled: true,
+                                backgroundColor: 'rgba(0,123,255,0.25)'
+                            },
+                            mode: 'xy',
+                        }
+                    }
+                }
+            }
         });
     }
 

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Visor y Editor de Flujo de Caja</title>
     <link rel="stylesheet" href="style.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/chartjs-plugin-zoom/2.0.1/chartjs-plugin-zoom.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>

--- a/style.css
+++ b/style.css
@@ -549,8 +549,8 @@ td.reimbursement-income {
 /* Estilos para Pestaña Gráfico */
 .chart-container {
     width: 100%;
-    max-width: 800px;
-    height: 400px;
+    max-width: 95%; /* Changed from 800px */
+    height: 60vh;   /* Changed from 400px */
     margin: 20px auto;
     border: 1px solid var(--border-color);
     border-radius: var(--radius);


### PR DESCRIPTION
This commit introduces several improvements to the cashflow chart:

- Increased Chart Size: The chart container in `style.css` has been modified to use `max-width: 95%` and `height: 60vh`, allowing the chart to utilize more available screen space.

- Zoom and Pan Functionality:
    - Added `chartjs-plugin-zoom` library via CDN in `index.html`.
    - Configured the plugin in `app.js` within the `renderCashflowChart` function's options.
    - You can now:
        - Zoom in/out using the mouse wheel.
        - Pan the chart by holding the Ctrl key and dragging. - Perform marquee zoom by clicking and dragging to select an area.

These changes address the issue of the chart being static and too small, especially when displaying many periods. The chart is now more dynamic and user-friendly.