### PR TITLE
Fix typo in default expense categories

### DIFF
--- a/app.js
+++ b/app.js
@@ -221,7 +221,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const DEFAULT_EXPENSE_CATEGORIES_JS = {
         "Arriendo": "Fijo", "Gastos Comunes": "Fijo", "Cuentas": "Fijo", "Suscripciones": "Fijo", "Ahorros": "Fijo", "Créditos": "Fijo", "Inversiones": "Fijo",
-        "Supermercado": "Variable", "Auto": "Variable", "Delivery": "Variable", "Salidas a comer": "Variable", "Minimarket": "Variable", "Uber": "Variable", "Regalos para alguien": "Variable", "Otros": "Variable", "Cosas de Casa": "Variable", "Salud": "Variable", "Panoramas": "Variable", "Ropa": "Variable", "Deporte": "Variable", "Vega": "Variable", "Transporte Publico": "Variable"
+        "Supermercado": "Variable", "Auto": "Variable", "Delivery": "Variable", "Salidas a comer": "Variable", "Minimarket": "Variable", "Uber": "Variable", "Regalos para alguien": "Variable", "Otros": "Variable", "Cosas de Casa": "Variable", "Salud": "Variable", "Panoramas": "Variable", "Ropa": "Variable", "Deporte": "Variable", "Vega": "Variable", "Transporte Público": "Variable"
     };
 
     // --- VALIDACIÓN DE CLAVES DE FIREBASE ---


### PR DESCRIPTION
## Summary
- fix accent in the default expense categories list in `app.js`

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_683f3cd996e083209b674f53e607c9fc