### PR TITLE
Add unsaved change warning

### DIFF
--- a/app.js
+++ b/app.js
@@ -747,6 +747,13 @@ document.addEventListener('DOMContentLoaded', () => {
         return names.map(n => n.charAt(0).toUpperCase() + n.slice(1)).join(' ');
     }
 
+    function hasUnsavedChanges() {
+        if (!originalLoadedData || !currentBackupData) return false;
+        const diffs = generateDetailedChangeLog(originalLoadedData, currentBackupData);
+        if (!diffs || diffs.length === 0) return false;
+        return !(diffs.length === 1 && diffs[0] === "No se detectaron cambios significativos en los datos.");
+    }
+
 
     // --- GUARDAR CAMBIOS (ÚNICO EVENT LISTENER) - MODIFICADO ---
     saveChangesButton.addEventListener('click', () => {
@@ -2341,4 +2348,13 @@ function getMondayOfWeek(year, week) {
     // Trigger change event on expense frequency select to apply initial state
     expenseFrequencySelect.dispatchEvent(new Event('change'));
     if (cashflowChartCanvas) cashflowChartCanvas.style.cursor = 'zoom-in';
+
+    window.addEventListener('beforeunload', (e) => {
+        if (hasUnsavedChanges()) {
+            const diffDetails = generateDetailedChangeLog(originalLoadedData, currentBackupData);
+            console.warn('Cambios sin guardar detectados:', diffDetails);
+            e.preventDefault();
+            e.returnValue = 'Tienes cambios sin guardar que se perderán si cierras la página.';
+        }
+    });
 }); // This is the closing of DOMContentLoaded


### PR DESCRIPTION
## Summary
- warn the user about unsaved changes when closing the page
- remove change log entry for unsaved close attempts

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_683f633b8b54832081c24a76601f6f97