### PR TITLE
Add mobile pinch zoom support

### DIFF
--- a/app.js
+++ b/app.js
@@ -97,6 +97,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const chartMessage = document.getElementById('chart-message');
     let cashflowChartInstance = null;
     let chartZoomMode = false;
+    const isTouchDevice = ('ontouchstart' in window) || navigator.maxTouchPoints > 0;
 
     // --- ELEMENTOS PESTAÑA BABY STEPS ---
     const babyStepsContainer = document.getElementById('baby-steps-container');
@@ -2036,8 +2037,13 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             }
         });
-        if (cashflowChartCanvas) cashflowChartCanvas.style.cursor = 'zoom-in';
-        if (chartMessage) chartMessage.textContent = 'Doble clic en el gráfico para activar el zoom.';
+        if (isTouchDevice) {
+            enableChartZoom();
+            if (chartMessage) chartMessage.textContent = 'Usa dos dedos para hacer zoom y mover el gráfico. Doble tap fuera del gráfico para salir.';
+        } else {
+            if (cashflowChartCanvas) cashflowChartCanvas.style.cursor = 'zoom-in';
+            if (chartMessage) chartMessage.textContent = 'Doble clic en el gráfico para activar el zoom.';
+        }
     }
 
     // --- LÓGICA PESTAÑA BABY STEPS ---

--- a/style.css
+++ b/style.css
@@ -556,6 +556,16 @@ td.reimbursement-income {
     border-radius: var(--radius);
     padding: 10px;
 }
+
+#cashflow-chart {
+    width: 100%;
+}
+
+@media (pointer: coarse) {
+    #cashflow-chart {
+        touch-action: none;
+    }
+}
 .centered-text {
     text-align: center;
     margin-top: 20px;


### PR DESCRIPTION
## Summary
- allow the chart to detect touch devices
- enable zoom by default on phones so pinch gestures work
- prevent page scrolling during pinch gestures with `touch-action: none`

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_683f6a9b80f48320adf73a911631e74b