### PR TITLE
Add simultaneous weekly and monthly cashflow views

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,8 @@
             <div class="tabs-container">
                 <button class="tab-button" data-tab="gastos">Gastos</button>
                 <button class="tab-button" data-tab="ingresos">Ingresos</button>
-                <button class="tab-button" data-tab="flujo-caja">Flujo de Caja</button>
+                <button class="tab-button" data-tab="flujo-caja-mensual">Flujo de Caja - Mensual</button>
+                <button class="tab-button" data-tab="flujo-caja-semanal">Flujo de Caja - Semanal</button>
                 <button class="tab-button" data-tab="grafico">Gráfico</button>
                 <button class="tab-button" data-tab="registro-pagos">Registro Pagos</button>
                 <button class="tab-button" data-tab="recordatorios">Recordatorios</button>
@@ -55,12 +56,6 @@
             <div id="ajustes" class="tab-content">
                 <h2>Ajustes del Análisis</h2>
                 <div class="form-container settings-form-container"> <form id="settings-form">
-                        <label for="analysis-periodicity-select">Periodicidad del Análisis:</label>
-                        <select id="analysis-periodicity-select">
-                            <option value="Mensual">Mensual</option>
-                            <option value="Semanal">Semanal</option>
-                        </select>
-
                         <label for="analysis-duration-input" id="analysis-duration-label">Duración (Meses):</label>
                         <input type="number" id="analysis-duration-input" value="12" min="1">
 
@@ -298,11 +293,23 @@
                 </div>
             </div>
             
-            <div id="flujo-caja" class="tab-content">
-                <div id="cashflow-container">
-                    <h2 id="cashflow-title">Flujo de Caja</h2>
+            <div id="flujo-caja-mensual" class="tab-content">
+                <div id="cashflow-mensual-container">
+                    <h2 id="cashflow-mensual-title">Flujo de Caja - Mensual</h2>
                     <div class="table-responsive">
-                        <table id="cashflow-table">
+                        <table id="cashflow-mensual-table">
+                            <thead></thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+
+            <div id="flujo-caja-semanal" class="tab-content">
+                <div id="cashflow-semanal-container">
+                    <h2 id="cashflow-semanal-title">Flujo de Caja - Semanal</h2>
+                    <div class="table-responsive">
+                        <table id="cashflow-semanal-table">
                             <thead></thead>
                             <tbody></tbody>
                         </table>


### PR DESCRIPTION
## Summary
- remove periodicity selection from settings
- add buttons for weekly and monthly cashflow views
- implement separate tables for weekly and monthly cashflow calculations
- update chart and tab activation logic

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_68405659a6c88320809a9ab0a4eca369