### PR TITLE
Add simultaneous weekly and monthly cashflow views

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,8 @@
             <div class="tabs-container">
                 <button class="tab-button" data-tab="gastos">Gastos</button>
                 <button class="tab-button" data-tab="ingresos">Ingresos</button>
-                <button class="tab-button" data-tab="flujo-caja">Flujo de Caja</button>
+                <button class="tab-button" data-tab="flujo-caja-mensual">Flujo de Caja - Mensual</button>
+                <button class="tab-button" data-tab="flujo-caja-semanal">Flujo de Caja - Semanal</button>
                 <button class="tab-button" data-tab="grafico">Gráfico</button>
                 <button class="tab-button" data-tab="registro-pagos">Registro Pagos</button>
                 <button class="tab-button" data-tab="recordatorios">Recordatorios</button>
@@ -55,12 +56,6 @@
             <div id="ajustes" class="tab-content">
                 <h2>Ajustes del Análisis</h2>
                 <div class="form-container settings-form-container"> <form id="settings-form">
-                        <label for="analysis-periodicity-select">Periodicidad del Análisis:</label>
-                        <select id="analysis-periodicity-select">
-                            <option value="Mensual">Mensual</option>
-                            <option value="Semanal">Semanal</option>
-                        </select>
-
                         <label for="analysis-duration-input" id="analysis-duration-label">Duración (Meses):</label>
                         <input type="number" id="analysis-duration-input" value="12" min="1">
 
@@ -298,11 +293,23 @@
                 </div>
             </div>
             
-            <div id="flujo-caja" class="tab-content">
-                <div id="cashflow-container">
-                    <h2 id="cashflow-title">Flujo de Caja</h2>
+            <div id="flujo-caja-mensual" class="tab-content">
+                <div id="cashflow-mensual-container">
+                    <h2 id="cashflow-mensual-title">Flujo de Caja - Mensual</h2>
                     <div class="table-responsive">
-                        <table id="cashflow-table">
+                        <table id="cashflow-mensual-table">
+                            <thead></thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+
+            <div id="flujo-caja-semanal" class="tab-content">
+                <div id="cashflow-semanal-container">
+                    <h2 id="cashflow-semanal-title">Flujo de Caja - Semanal</h2>
+                    <div class="table-responsive">
+                        <table id="cashflow-semanal-table">
                             <thead></thead>
                             <tbody></tbody>
                         </table>

--- a/style.css
+++ b/style.css
@@ -367,8 +367,12 @@ td.reimbursement-income {
 
 
 /* Contenedor de flujo de caja */
-#cashflow-container { margin-top: 20px; padding: 0; }
-#cashflow-title { text-align: center; margin-bottom: 15px; color: var(--text-color); font-size: 1.6rem; }
+#cashflow-container,
+#cashflow-mensual-container,
+#cashflow-semanal-container { margin-top: 20px; padding: 0; }
+#cashflow-title,
+#cashflow-mensual-title,
+#cashflow-semanal-title { text-align: center; margin-bottom: 15px; color: var(--text-color); font-size: 1.6rem; }
 
 /* Tabla responsive (Flujo de Caja) */
 .table-responsive {
@@ -379,21 +383,27 @@ td.reimbursement-income {
   box-shadow: var(--shadow);
 }
 
-#cashflow-table {
+#cashflow-table,
+#cashflow-mensual-table,
+#cashflow-semanal-table {
   width: 100%;
   min-width: 600px;
   border-collapse: separate;
   border-spacing: 0;
   font-size: 0.76rem;
 }
-#cashflow-table th, #cashflow-table td {
+#cashflow-table th, #cashflow-table td,
+#cashflow-mensual-table th, #cashflow-mensual-table td,
+#cashflow-semanal-table th, #cashflow-semanal-table td {
   padding: 10px 12px;
   text-align: left;
   border-bottom: 1px solid var(--border-color);
   white-space: nowrap;
   background-color: var(--card-bg);
 }
-#cashflow-table thead th {
+#cashflow-table thead th,
+#cashflow-mensual-table thead th,
+#cashflow-semanal-table thead th {
   background-color: var(--header-bg);
   color: var(--primary-color);
   font-weight: 600;
@@ -403,16 +413,24 @@ td.reimbursement-income {
   z-index: 10;
 }
 #cashflow-table th:first-child,
-#cashflow-table td:first-child {
+#cashflow-table td:first-child,
+#cashflow-mensual-table th:first-child,
+#cashflow-mensual-table td:first-child,
+#cashflow-semanal-table th:first-child,
+#cashflow-semanal-table td:first-child {
   position: sticky;
   left: 0;
 }
-#cashflow-table thead th:first-child {
+#cashflow-table thead th:first-child,
+#cashflow-mensual-table thead th:first-child,
+#cashflow-semanal-table thead th:first-child {
   text-align: left;
   z-index: 11;
   background-color: var(--header-bg);
 }
-#cashflow-table tbody td:first-child {
+#cashflow-table tbody td:first-child,
+#cashflow-mensual-table tbody td:first-child,
+#cashflow-semanal-table tbody td:first-child {
   font-weight: 500;
   z-index: 9;
   background-color: var(--card-bg);
@@ -420,19 +438,33 @@ td.reimbursement-income {
 
 /* Estilos para filas especiales en Flujo de Caja */
 #cashflow-table tbody tr.bg-alt-row td,
-#cashflow-table tbody tr.bg-alt-row td:first-child {
+#cashflow-table tbody tr.bg-alt-row td:first-child,
+#cashflow-mensual-table tbody tr.bg-alt-row td,
+#cashflow-mensual-table tbody tr.bg-alt-row td:first-child,
+#cashflow-semanal-table tbody tr.bg-alt-row td,
+#cashflow-semanal-table tbody tr.bg-alt-row td:first-child {
   background-color: var(--alt-row-bg) !important;
 }
 #cashflow-table tbody tr.bg-header td,
-#cashflow-table tbody tr.bg-header td:first-child {
+#cashflow-table tbody tr.bg-header td:first-child,
+#cashflow-mensual-table tbody tr.bg-header td,
+#cashflow-mensual-table tbody tr.bg-header td:first-child,
+#cashflow-semanal-table tbody tr.bg-header td,
+#cashflow-semanal-table tbody tr.bg-header td:first-child {
   background-color: var(--body-header-row-bg) !important;
 }
 #cashflow-table tbody tr:not(.bg-header):hover td,
-#cashflow-table tbody tr:not(.bg-header):hover td:first-child {
+#cashflow-table tbody tr:not(.bg-header):hover td:first-child,
+#cashflow-mensual-table tbody tr:not(.bg-header):hover td,
+#cashflow-mensual-table tbody tr:not(.bg-header):hover td:first-child,
+#cashflow-semanal-table tbody tr:not(.bg-header):hover td,
+#cashflow-semanal-table tbody tr:not(.bg-header):hover td:first-child {
   background-color: var(--row-hover-bg) !important;
 }
 
-#cashflow-table td:not(:first-child) {
+#cashflow-table td:not(:first-child),
+#cashflow-mensual-table td:not(:first-child),
+#cashflow-semanal-table td:not(:first-child) {
   text-align: right;
   font-family: 'Consolas', monospace;
 }


### PR DESCRIPTION
## Summary
- remove periodicity selection from settings
- add buttons for weekly and monthly cashflow views
- implement separate tables for weekly and monthly cashflow calculations
- update chart and tab activation logic

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_68405659a6c88320809a9ab0a4eca369