### PR TITLE
Add data export feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,7 @@
                         <p id="usd-clp-info-label" class="small-text informative-rate">1 USD = $CLP (Obteniendo...)</p>
 
                         <button type="button" id="apply-settings-button" class="accent">Aplicar Ajustes y Recalcular</button>
+                        <button type="button" id="download-csv-button">Descargar Datos CSV</button>
                     </form>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add export button to Ajustes
- enable CSV download of key data tables with Spanish formatting

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_68405e215a588320bd8beecc461f1cec