### PR TITLE
Add category distribution pie charts

### DIFF
--- a/app.js
+++ b/app.js
@@ -124,6 +124,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const pieWeekApply = document.getElementById('pie-week-apply');
     const pieMonthCanvas = document.getElementById('pie-chart-month');
     const pieWeekCanvas = document.getElementById('pie-chart-week');
+    const pieMonthContainer = document.getElementById('pie-month-container');
+    const pieWeekContainer = document.getElementById('pie-week-container');
     let cashflowChartInstance = null;
     let pieMonthChartInstance = null;
     let pieWeekChartInstance = null;
@@ -302,8 +304,8 @@ document.addEventListener('DOMContentLoaded', () => {
         mainContentContainer.style.display = 'block';
         activateTab('gastos'); // Activate a default tab
         fetchAndUpdateUSDCLPRate(); // Fetch USD/CLP rate when main content is shown
-        if (pieMonthApply) pieMonthApply.click();
-        if (pieWeekApply) pieWeekApply.click();
+        if (typeof updatePieMonthChart === 'function') updatePieMonthChart();
+        if (typeof updatePieWeekChart === 'function') updatePieWeekChart();
     }
 
     function clearAllDataViews() {
@@ -1056,6 +1058,12 @@ document.addEventListener('DOMContentLoaded', () => {
             const activeBtn = chartSubtabs.querySelector(`.subtab-button[data-period="${periodicity}"]`);
             if (activeBtn) activeBtn.classList.add('active');
             if (graficoTitle) graficoTitle.textContent = `Gráfico de Flujo de Caja - ${periodicity}`;
+            if (pieMonthContainer && pieWeekContainer) {
+                pieMonthContainer.style.display = periodicity === 'Mensual' ? 'block' : 'none';
+                pieWeekContainer.style.display = periodicity === 'Semanal' ? 'block' : 'none';
+            }
+            if (periodicity === 'Mensual' && typeof updatePieMonthChart === 'function') updatePieMonthChart();
+            if (periodicity === 'Semanal' && typeof updatePieWeekChart === 'function') updatePieWeekChart();
             renderCashflowTable();
         }
     }
@@ -2761,20 +2769,27 @@ function getMondayOfWeek(year, week) {
         const [ywYear, ywWeek] = getWeekNumber(today);
         pieWeekInput.value = `${ywYear}-W${('0'+ywWeek).slice(-2)}`;
     }
-    if (pieMonthApply) pieMonthApply.addEventListener('click', () => {
+
+    function updatePieMonthChart() {
         const val = pieMonthInput.value;
         if (!val) return;
         const [y,m] = val.split('-').map(Number);
         const start = new Date(Date.UTC(y, m-1, 1));
         pieMonthChartInstance = renderExpenseDistributionChart(start, 'Mensual', pieMonthCanvas, pieMonthChartInstance);
-    });
-    if (pieWeekApply) pieWeekApply.addEventListener('click', () => {
+    }
+
+    function updatePieWeekChart() {
         const val = pieWeekInput.value;
         if (!val) return;
         const [y,w] = val.split('-W');
         const start = getMondayOfWeek(parseInt(y), parseInt(w));
         pieWeekChartInstance = renderExpenseDistributionChart(start, 'Semanal', pieWeekCanvas, pieWeekChartInstance);
-    });
+    }
+
+    if (pieMonthApply) pieMonthApply.addEventListener('click', updatePieMonthChart);
+    if (pieWeekApply) pieWeekApply.addEventListener('click', updatePieWeekChart);
+    if (pieMonthInput) pieMonthInput.addEventListener('change', updatePieMonthChart);
+    if (pieWeekInput) pieWeekInput.addEventListener('change', updatePieWeekChart);
 
     // --- CONFIGURAR ZOOM EN EL GRÁFICO ---
     function enableChartZoom() {

--- a/app.js
+++ b/app.js
@@ -118,7 +118,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const applyMobileChartRangeButton = document.getElementById('apply-mobile-chart-range');
     const chartSubtabs = document.getElementById('chart-subtabs');
     const graficoTitle = document.getElementById('grafico-title');
+    const pieMonthInput = document.getElementById('pie-month-input');
+    const pieWeekInput = document.getElementById('pie-week-input');
+    const pieMonthApply = document.getElementById('pie-month-apply');
+    const pieWeekApply = document.getElementById('pie-week-apply');
+    const pieMonthCanvas = document.getElementById('pie-chart-month');
+    const pieWeekCanvas = document.getElementById('pie-chart-week');
     let cashflowChartInstance = null;
+    let pieMonthChartInstance = null;
+    let pieWeekChartInstance = null;
     let chartZoomMode = false;
     const isTouchDevice = ('ontouchstart' in window) || navigator.maxTouchPoints > 0;
     let fullChartData = null;
@@ -294,6 +302,8 @@ document.addEventListener('DOMContentLoaded', () => {
         mainContentContainer.style.display = 'block';
         activateTab('gastos'); // Activate a default tab
         fetchAndUpdateUSDCLPRate(); // Fetch USD/CLP rate when main content is shown
+        if (pieMonthApply) pieMonthApply.click();
+        if (pieWeekApply) pieWeekApply.click();
     }
 
     function clearAllDataViews() {
@@ -326,8 +336,12 @@ document.addEventListener('DOMContentLoaded', () => {
             cashflowChartInstance.destroy();
             cashflowChartInstance = null;
         }
+        if (pieMonthChartInstance) { pieMonthChartInstance.destroy(); pieMonthChartInstance = null; }
+        if (pieWeekChartInstance) { pieWeekChartInstance.destroy(); pieWeekChartInstance = null; }
         if (chartMessage) chartMessage.textContent = "El gráfico se generará después de calcular el flujo de caja.";
         if (usdClpInfoLabel) usdClpInfoLabel.textContent = "1 USD = $CLP (Obteniendo...)";
+        if (pieMonthInput) pieMonthInput.value = '';
+        if (pieWeekInput) pieWeekInput.value = '';
     }
 
     // --- AUTENTICACIÓN ---
@@ -2359,6 +2373,114 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    function getExpenseOccurrencesInPeriod(expense, pStart, pEnd, periodicity) {
+        if (!expense.start_date) return 0;
+        const start = new Date(expense.start_date);
+        const end = expense.end_date ? new Date(expense.end_date) : null;
+        const freq = expense.frequency || 'Mensual';
+
+        if (freq === 'Único') {
+            return (start >= pStart && start <= pEnd) ? 1 : 0;
+        } else if (freq === 'Mensual') {
+            if (start > pEnd || (end && end < pStart)) return 0;
+            const payDay = start.getUTCDate();
+            if (periodicity === 'Semanal') {
+                const payDate = new Date(Date.UTC(pStart.getUTCFullYear(), pStart.getUTCMonth(), payDay));
+                return (payDate >= pStart && payDate <= pEnd && start <= payDate && (!end || end >= payDate)) ? 1 : 0;
+            } else {
+                const year = pStart.getUTCFullYear();
+                const month = pStart.getUTCMonth();
+                const daysInMonth = getDaysInMonth(year, month);
+                const payDate = new Date(Date.UTC(year, month, Math.min(payDay, daysInMonth)));
+                return (payDate >= pStart && payDate <= pEnd && start <= payDate && (!end || end >= payDate)) ? 1 : 0;
+            }
+        } else if (freq === 'Semanal') {
+            if (start > pEnd || (end && end < pStart)) return 0;
+            if (periodicity === 'Semanal') {
+                return 1;
+            } else {
+                let count = 0;
+                const payDow = start.getUTCDay();
+                let d = new Date(pStart.getTime());
+                while (d <= pEnd) {
+                    if (d.getUTCDay() === payDow && d >= start && (!end || d <= end)) count++;
+                    d.setUTCDate(d.getUTCDate() + 1);
+                }
+                return count;
+            }
+        } else if (freq === 'Bi-semanal') {
+            if (start > pEnd || (end && end < pStart)) return 0;
+            let count = 0;
+            let payDate = new Date(start.getTime());
+            while (payDate < pStart) {
+                payDate = addWeeks(payDate, 2);
+                if (end && payDate > end) return count;
+            }
+            while (payDate <= pEnd) {
+                if (!end || payDate <= end) count++;
+                payDate = addWeeks(payDate, 2);
+            }
+            return count;
+        }
+        return 0;
+    }
+
+    function calculateExpenseDistribution(periodStart, periodicity) {
+        const periodEnd = getPeriodEndDate(periodStart, periodicity);
+        const totals = {};
+        const methodTotals = {};
+        (currentBackupData.expenses || []).forEach(exp => {
+            const occ = getExpenseOccurrencesInPeriod(exp, periodStart, periodEnd, periodicity);
+            if (occ <= 0) return;
+            const amt = parseFloat(exp.amount || 0) * occ;
+            if (!totals[exp.category]) {
+                totals[exp.category] = 0;
+                methodTotals[exp.category] = { Efectivo: 0, Credito: 0 };
+            }
+            totals[exp.category] += amt;
+            if (exp.payment_method === 'Credito') methodTotals[exp.category].Credito += amt;
+            else methodTotals[exp.category].Efectivo += amt;
+        });
+        return { totals, methodTotals };
+    }
+
+    function renderExpenseDistributionChart(periodStart, periodicity, canvas, existingInstance) {
+        if (!canvas) return null;
+        const { totals, methodTotals } = calculateExpenseDistribution(periodStart, periodicity);
+        const categories = Object.keys(totals).filter(cat => totals[cat] > 0);
+        if (existingInstance) { existingInstance.destroy(); }
+        if (categories.length === 0) {
+            const ctx = canvas.getContext('2d');
+            ctx.clearRect(0,0,canvas.width,canvas.height);
+            return null;
+        }
+        const data = categories.map(cat => totals[cat]);
+        const colors = categories.map((_,i) => `hsl(${(i*60)%360},70%,60%)`);
+        const newChart = new Chart(canvas, {
+            type: 'doughnut',
+            data: { labels: categories, datasets: [{ data, backgroundColor: colors }] },
+            options: {
+                plugins: {
+                    tooltip: {
+                        callbacks: {
+                            label: function(ctx) {
+                                const cat = ctx.label;
+                                const total = totals[cat] || 0;
+                                const cash = methodTotals[cat].Efectivo || 0;
+                                const credit = methodTotals[cat].Credito || 0;
+                                const pcash = total ? ((cash/total)*100).toFixed(1) : '0';
+                                const pcred = total ? ((credit/total)*100).toFixed(1) : '0';
+                                return `${cat}: ${formatCurrencyJS(total, currentBackupData.display_currency_symbol || '$')} (Efec: ${pcash}%, Cred: ${pcred}%)`;
+                            }
+                        }
+                    },
+                    legend: { position: 'bottom' }
+                }
+            }
+        });
+        return newChart;
+    }
+
     // --- LÓGICA PESTAÑA BABY STEPS ---
     function renderBabySteps() {
         if (!babyStepsContainer || !currentBackupData || !currentBackupData.baby_steps_status) return;
@@ -2633,6 +2755,26 @@ function getMondayOfWeek(year, week) {
             applyMobileChartRangeButton.addEventListener('click', applyMobileChartRange);
         }
     }
+
+    if (pieMonthInput) pieMonthInput.value = today.toISOString().slice(0,7);
+    if (pieWeekInput) {
+        const [ywYear, ywWeek] = getWeekNumber(today);
+        pieWeekInput.value = `${ywYear}-W${('0'+ywWeek).slice(-2)}`;
+    }
+    if (pieMonthApply) pieMonthApply.addEventListener('click', () => {
+        const val = pieMonthInput.value;
+        if (!val) return;
+        const [y,m] = val.split('-').map(Number);
+        const start = new Date(Date.UTC(y, m-1, 1));
+        pieMonthChartInstance = renderExpenseDistributionChart(start, 'Mensual', pieMonthCanvas, pieMonthChartInstance);
+    });
+    if (pieWeekApply) pieWeekApply.addEventListener('click', () => {
+        const val = pieWeekInput.value;
+        if (!val) return;
+        const [y,w] = val.split('-W');
+        const start = getMondayOfWeek(parseInt(y), parseInt(w));
+        pieWeekChartInstance = renderExpenseDistributionChart(start, 'Semanal', pieWeekCanvas, pieWeekChartInstance);
+    });
 
     // --- CONFIGURAR ZOOM EN EL GRÁFICO ---
     function enableChartZoom() {

--- a/app.js
+++ b/app.js
@@ -120,8 +120,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const graficoTitle = document.getElementById('grafico-title');
     const pieMonthInput = document.getElementById('pie-month-input');
     const pieWeekInput = document.getElementById('pie-week-input');
-    const pieMonthApply = document.getElementById('pie-month-apply');
-    const pieWeekApply = document.getElementById('pie-week-apply');
     const pieMonthCanvas = document.getElementById('pie-chart-month');
     const pieWeekCanvas = document.getElementById('pie-chart-week');
     const pieMonthContainer = document.getElementById('pie-month-container');
@@ -2786,8 +2784,6 @@ function getMondayOfWeek(year, week) {
         pieWeekChartInstance = renderExpenseDistributionChart(start, 'Semanal', pieWeekCanvas, pieWeekChartInstance);
     }
 
-    if (pieMonthApply) pieMonthApply.addEventListener('click', updatePieMonthChart);
-    if (pieWeekApply) pieWeekApply.addEventListener('click', updatePieWeekChart);
     if (pieMonthInput) pieMonthInput.addEventListener('change', updatePieMonthChart);
     if (pieWeekInput) pieWeekInput.addEventListener('change', updatePieWeekChart);
 

--- a/index.html
+++ b/index.html
@@ -370,7 +370,6 @@
                     <h3>Distribución de Gastos por Categoría - Mensual</h3>
                     <div class="chart-period-selector">
                         <input type="month" id="pie-month-input">
-                        <button id="pie-month-apply">Mostrar</button>
                     </div>
                     <div class="chart-container">
                         <canvas id="pie-chart-month"></canvas>
@@ -381,7 +380,6 @@
                     <h3>Distribución de Gastos por Categoría - Semanal</h3>
                     <div class="chart-period-selector">
                         <input type="week" id="pie-week-input">
-                        <button id="pie-week-apply">Mostrar</button>
                     </div>
                     <div class="chart-container">
                         <canvas id="pie-chart-week"></canvas>

--- a/index.html
+++ b/index.html
@@ -365,6 +365,24 @@
                     <button id="apply-mobile-chart-range">Aplicar</button>
                 </div>
                 <p id="chart-message" class="centered-text">Doble clic en el gráfico para activar el zoom.</p>
+
+                <h3>Distribución de Gastos por Categoría - Mensual</h3>
+                <div class="chart-period-selector">
+                    <input type="month" id="pie-month-input">
+                    <button id="pie-month-apply">Mostrar</button>
+                </div>
+                <div class="chart-container">
+                    <canvas id="pie-chart-month"></canvas>
+                </div>
+
+                <h3>Distribución de Gastos por Categoría - Semanal</h3>
+                <div class="chart-period-selector">
+                    <input type="week" id="pie-week-input">
+                    <button id="pie-week-apply">Mostrar</button>
+                </div>
+                <div class="chart-container">
+                    <canvas id="pie-chart-week"></canvas>
+                </div>
             </div>
 
             <div id="baby-steps" class="tab-content">

--- a/index.html
+++ b/index.html
@@ -366,22 +366,26 @@
                 </div>
                 <p id="chart-message" class="centered-text">Doble clic en el gráfico para activar el zoom.</p>
 
-                <h3>Distribución de Gastos por Categoría - Mensual</h3>
-                <div class="chart-period-selector">
-                    <input type="month" id="pie-month-input">
-                    <button id="pie-month-apply">Mostrar</button>
-                </div>
-                <div class="chart-container">
-                    <canvas id="pie-chart-month"></canvas>
+                <div id="pie-month-container">
+                    <h3>Distribución de Gastos por Categoría - Mensual</h3>
+                    <div class="chart-period-selector">
+                        <input type="month" id="pie-month-input">
+                        <button id="pie-month-apply">Mostrar</button>
+                    </div>
+                    <div class="chart-container">
+                        <canvas id="pie-chart-month"></canvas>
+                    </div>
                 </div>
 
-                <h3>Distribución de Gastos por Categoría - Semanal</h3>
-                <div class="chart-period-selector">
-                    <input type="week" id="pie-week-input">
-                    <button id="pie-week-apply">Mostrar</button>
-                </div>
-                <div class="chart-container">
-                    <canvas id="pie-chart-week"></canvas>
+                <div id="pie-week-container" style="display:none;">
+                    <h3>Distribución de Gastos por Categoría - Semanal</h3>
+                    <div class="chart-period-selector">
+                        <input type="week" id="pie-week-input">
+                        <button id="pie-week-apply">Mostrar</button>
+                    </div>
+                    <div class="chart-container">
+                        <canvas id="pie-chart-week"></canvas>
+                    </div>
                 </div>
             </div>
 

--- a/style.css
+++ b/style.css
@@ -659,6 +659,7 @@ td.reimbursement-income {
 
 #cashflow-chart {
     width: 100%;
+    max-width: none;
 }
 
 .mobile-chart-range {

--- a/style.css
+++ b/style.css
@@ -626,6 +626,19 @@ td.reimbursement-income {
     margin-bottom: 0;
 }
 
+/* Selector de período para gráficos adicionales */
+.chart-period-selector {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    margin-top: 10px;
+}
+.chart-period-selector input,
+.chart-period-selector button {
+    padding: 6px 8px;
+}
+
 /* Estilos para Pestaña Gráfico */
 .chart-container {
     width: 100%;

--- a/style.css
+++ b/style.css
@@ -650,6 +650,13 @@ td.reimbursement-income {
     padding: 10px;
 }
 
+.chart-container canvas {
+    display: block;
+    width: 100%;
+    max-width: 600px;
+    margin: 0 auto;
+}
+
 #cashflow-chart {
     width: 100%;
 }


### PR DESCRIPTION
## Summary
- add monthly and weekly expense distribution charts
- include period selectors for new charts
- style period selector
- compute breakdown of cash vs credit for each category

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_6840f6d070a883209c2e512363b0fc16