### PR TITLE
Add Instant Expense toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,11 @@
 
                         <label for="display-currency-symbol-input">Símbolo Moneda:</label>
                         <input type="text" id="display-currency-symbol-input" value="$" maxlength="5">
+
+                        <div class="checkbox-container">
+                            <input type="checkbox" id="instant-expense-toggle">
+                            <label for="instant-expense-toggle">Modo Gastos Instantáneos</label>
+                        </div>
                         
                         <p id="usd-clp-info-label" class="small-text informative-rate">1 USD = $CLP (Obteniendo...)</p>
 


### PR DESCRIPTION
## Summary
- add 'Gastos Instantáneos' switch in Ajustes
- support instant expense mode in calculation and charts
- update titles according to analysis mode
- extend tests for new behaviour

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_684106c274888320b5c98c33aa829dbb