### PR TITLE
Implement credit card editing and usage restrictions

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,7 @@
                         <input type="number" id="credit-card-payment-day" min="1" max="31" required>
                         <p id="credit-card-example" class="small-text"></p>
                         <button type="submit" id="add-credit-card-button">Agregar Tarjeta</button>
+                        <button type="button" id="cancel-edit-credit-card-button" style="display:none;" class="danger">Cancelar Edición</button>
                     </form>
                     <ul id="credit-cards-list"></ul>
                 </div>


### PR DESCRIPTION
## Summary
- allow editing credit cards
- add cancel button for credit card edit
- disable edit/delete when the card is referenced by expenses

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_6841b38696f48320bc1017059408e132