### PR TITLE
Implement edit lock

### DIFF
--- a/app.js
+++ b/app.js
@@ -84,6 +84,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const searchExpenseInput = document.getElementById('search-expense-input');
     let editingExpenseIndex = null;
 
+    // --- BLOQUEO DE EDICIÓN ---
+    let editLockAcquired = false;
+    let editLockRef = null;
+
     // --- ELEMENTOS PESTAÑA PRESUPUESTOS ---
     const budgetForm = document.getElementById('budget-form');
     const budgetCategorySelect = document.getElementById('budget-category-select');
@@ -292,13 +296,48 @@ document.addEventListener('DOMContentLoaded', () => {
         loadLatestVersionButton.disabled = true;
     }
 
-    function showDataSelectionScreen(user) {
+    async function acquireEditLock(user) {
+        const ref = getEditLockRefByUID(user.uid);
+        if (!ref) return false;
+        try {
+            const result = await ref.transaction(current => {
+                if (current === null || current.uid === user.uid) {
+                    return { uid: user.uid, timestamp: firebase.database.ServerValue.TIMESTAMP };
+                }
+                return;
+            });
+            if (result.committed && result.snapshot.val() && result.snapshot.val().uid === user.uid) {
+                editLockRef = ref;
+                editLockAcquired = true;
+                ref.onDisconnect().remove();
+                return true;
+            }
+        } catch (e) { }
+        return false;
+    }
+
+    function releaseEditLock() {
+        if (editLockAcquired && editLockRef) {
+            editLockRef.remove();
+            editLockAcquired = false;
+            editLockRef = null;
+        }
+    }
+
+    async function showDataSelectionScreen(user) {
         authContainer.style.display = 'block';
         loginForm.style.display = 'none';
         logoutArea.style.display = 'block';
-        authStatus.textContent = `Conectado como: ${user.email}`; 
-        dataSelectionContainer.style.display = 'block';
+        authStatus.textContent = `Conectado como: ${user.email}`;
+        dataSelectionContainer.style.display = 'none';
         mainContentContainer.style.display = 'none';
+
+        const locked = await acquireEditLock(user);
+        if (!locked) {
+            authStatus.textContent = 'Otro usuario está editando los datos en este momento.';
+            return;
+        }
+        dataSelectionContainer.style.display = 'block';
         fetchBackups();
     }
 
@@ -362,7 +401,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 authStatus.textContent = '';
             });
     });
-    logoutButton.addEventListener('click', () => { auth.signOut(); });
+    logoutButton.addEventListener('click', () => { releaseEditLock(); auth.signOut(); });
     auth.onAuthStateChanged(user => user ? showDataSelectionScreen(user) : showLoginScreen());
 
     // --- CARGA DE VERSIONES (BACKUPS) ---
@@ -2945,5 +2984,6 @@ function getMondayOfWeek(year, week) {
             e.preventDefault();
             e.returnValue = '';
         }
+        releaseEditLock();
     });
 }); // This is the closing of DOMContentLoaded

--- a/config.js
+++ b/config.js
@@ -60,3 +60,22 @@ function getUserDataRef() {
     const user = auth.currentUser;
     return user ? getUserDataRefByUID(user.uid) : null;
 }
+
+/**
+ * Devuelve una referencia al bloqueo de edición para el UID dado.
+ * @param {string} uid
+ * @returns {firebase.database.Reference|null}
+ */
+function getEditLockRefByUID(uid) {
+    const path = getUserDataPath(uid);
+    return path ? database.ref(`${path}/edit_lock`) : null;
+}
+
+/**
+ * Devuelve una referencia al bloqueo de edición para el usuario actual.
+ * @returns {firebase.database.Reference|null}
+ */
+function getEditLockRef() {
+    const user = auth.currentUser;
+    return user ? getEditLockRefByUID(user.uid) : null;
+}


### PR DESCRIPTION
## Summary
- add helper functions to get edit lock references in Firebase
- implement edit lock acquire and release logic
- prevent simultaneous editing by checking for an existing lock on login
- release the lock when logging out or closing the page

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_6841b45472f0832097b3ba0fbf3b99aa