### PR TITLE
Enable chart-driven transaction filtering

### DIFF
--- a/index.html
+++ b/index.html
@@ -439,6 +439,26 @@
             <div class="save-changes-container">
                  <button id="save-changes-button" class="accent">Guardar Nueva Versión</button>
             </div>
+            <div id="chart-modal" class="modal" style="display:none;">
+                <div class="modal-content">
+                    <span id="chart-modal-close" class="modal-close">&times;</span>
+                    <h3 id="chart-modal-title"></h3>
+                    <div class="table-responsive">
+                        <table id="chart-modal-table">
+                            <thead>
+                                <tr>
+                                    <th>Tipo</th>
+                                    <th>Nombre</th>
+                                    <th>Monto</th>
+                                    <th>Categoría</th>
+                                    <th>Fecha</th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -1138,3 +1138,35 @@ td.reimbursement-income {
 }
 
 /* End of Added Styles for Baby Steps Interactivity */
+
+/* Modal for chart transactions */
+.modal {
+    position: fixed;
+    z-index: 1000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgba(0,0,0,0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.modal-content {
+    background: var(--card-bg);
+    padding: 20px;
+    border-radius: var(--radius);
+    width: 90%;
+    max-width: 600px;
+    max-height: 80vh;
+    overflow-y: auto;
+    box-shadow: var(--shadow);
+}
+
+.modal-close {
+    float: right;
+    font-size: 1.5em;
+    cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- implement modal markup for chart-click transactions
- style modal overlay and content
- add income occurrence helper and transaction gathering logic
- open modal when clicking pie chart segments or cashflow chart points

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_6841efcc8234832089b69b55e8f60644