### PR TITLE
Add multi pie charts

### DIFF
--- a/index.html
+++ b/index.html
@@ -380,22 +380,44 @@
 
                 <div id="pie-month-container">
                     <h3>Distribución de Gastos por Categoría - Mensual</h3>
-                    <div class="chart-period-selector">
-                        <input type="month" id="pie-month-input">
+                    <div class="chart-period-selector multi-input">
+                        <input type="month" id="pie-month-input-1">
+                        <input type="month" id="pie-month-input-2">
+                        <input type="month" id="pie-month-input-3">
                     </div>
-                    <div class="chart-container">
-                        <canvas id="pie-chart-month"></canvas>
+                    <div class="multi-pie-container">
+                        <div class="chart-container">
+                            <canvas id="pie-chart-month-1"></canvas>
+                        </div>
+                        <div class="chart-container">
+                            <canvas id="pie-chart-month-2"></canvas>
+                        </div>
+                        <div class="chart-container">
+                            <canvas id="pie-chart-month-3"></canvas>
+                        </div>
                     </div>
+                    <div id="pie-month-legend" class="shared-legend"></div>
                 </div>
 
                 <div id="pie-week-container" style="display:none;">
                     <h3>Distribución de Gastos por Categoría - Semanal</h3>
-                    <div class="chart-period-selector">
-                        <input type="week" id="pie-week-input">
+                    <div class="chart-period-selector multi-input">
+                        <input type="week" id="pie-week-input-1">
+                        <input type="week" id="pie-week-input-2">
+                        <input type="week" id="pie-week-input-3">
                     </div>
-                    <div class="chart-container">
-                        <canvas id="pie-chart-week"></canvas>
+                    <div class="multi-pie-container">
+                        <div class="chart-container">
+                            <canvas id="pie-chart-week-1"></canvas>
+                        </div>
+                        <div class="chart-container">
+                            <canvas id="pie-chart-week-2"></canvas>
+                        </div>
+                        <div class="chart-container">
+                            <canvas id="pie-chart-week-3"></canvas>
+                        </div>
                     </div>
+                    <div id="pie-week-legend" class="shared-legend"></div>
                 </div>
             </div>
 

--- a/style.css
+++ b/style.css
@@ -673,6 +673,49 @@ td.reimbursement-income {
     padding: 6px 8px;
 }
 
+.multi-pie-container {
+    display: flex;
+    justify-content: center;
+    gap: 20px;
+    flex-wrap: wrap;
+}
+
+.multi-pie-container .chart-container {
+    flex: 1 1 250px;
+    max-width: 300px;
+    height: 40vh;
+    margin: 10px;
+}
+
+.shared-legend {
+    text-align: center;
+    margin-top: 10px;
+}
+
+.shared-legend ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.shared-legend li {
+    display: flex;
+    align-items: center;
+    font-size: 0.9rem;
+}
+
+.legend-color {
+    width: 12px;
+    height: 12px;
+    display: inline-block;
+    margin-right: 4px;
+    border-radius: 2px;
+}
+
 /* Estilos para Pestaña Gráfico */
 .chart-container {
     width: 100%;


### PR DESCRIPTION
## Summary
- allow comparing three different periods in the pie chart view
- share a legend between the charts and keep category colors consistent
- align slice order across charts so repeated categories stay in the same position

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_6842303f713083209445d772d93e2be1