### PR TITLE
Fix credit card editing restrictions

### DIFF
--- a/app.js
+++ b/app.js
@@ -1240,9 +1240,9 @@ document.addEventListener('DOMContentLoaded', () => {
             const editBtn = document.createElement('button');
             editBtn.textContent = 'Editar';
             editBtn.classList.add('small-button');
-            editBtn.disabled = isInUse;
+            // La edición debe permitirse aunque la tarjeta esté en uso.
             editBtn.title = isInUse ? 'Tarjeta en uso por gastos' : 'Editar tarjeta';
-            editBtn.addEventListener('click', () => { if (!isInUse) loadCreditCardForEdit(idx); });
+            editBtn.addEventListener('click', () => { loadCreditCardForEdit(idx); });
             li.appendChild(editBtn);
 
             const delBtn = document.createElement('button');
@@ -1358,10 +1358,22 @@ document.addEventListener('DOMContentLoaded', () => {
 
             const cardData = { name: name, cutoff_day: cutoff, payment_day: payDay };
             if (editingCreditCardIndex !== null) {
+                const oldName = currentBackupData.credit_cards[editingCreditCardIndex].name;
                 currentBackupData.credit_cards[editingCreditCardIndex] = cardData;
+                // Actualizar gastos que usen esta tarjeta si cambió el nombre
+                if (oldName !== name && currentBackupData.expenses) {
+                    currentBackupData.expenses.forEach(exp => {
+                        if (exp.payment_method === 'Credito' && exp.credit_card === oldName) {
+                            exp.credit_card = name;
+                        }
+                    });
+                }
             } else {
                 currentBackupData.credit_cards.push(cardData);
             }
+
+            // Refrescar vista de gastos para reflejar cambios de nombre
+            renderExpensesTable();
 
             renderCreditCards();
             resetCreditCardForm();


### PR DESCRIPTION
## Summary
- allow editing a credit card even if it has associated expenses
- update expenses when a card name changes so references stay consistent

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_68430a50976c8320be73268cfeb76c1a