### PR TITLE
Fix default movement date

### DIFF
--- a/app.js
+++ b/app.js
@@ -1729,7 +1729,7 @@ document.addEventListener('DOMContentLoaded', () => {
     addExpenseButton.textContent = 'Agregar Gasto'; 
     cancelEditExpenseButton.style.display = 'none';
         editingExpenseIndex = null;
-        const defaultDate = getISODateString(currentBackupData && currentBackupData.analysis_start_date ? new Date(currentBackupData.analysis_start_date) : new Date());
+        const defaultDate = getISODateString(new Date());
         expenseMovementDateInput.value = defaultDate;
         updateExpensePaymentDate();
         updateRemoveCategoryButtonState();


### PR DESCRIPTION
## Summary
- always use today's date as default for expense movement date

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_6846e397aed883209b57a8628e874283