### PR TITLE
Fix payment tab defaults

### DIFF
--- a/app.js
+++ b/app.js
@@ -1926,8 +1926,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // --- LÓGICA PESTAÑA REGISTRO PAGOS ---
     function setupPaymentPeriodSelectors() {
-        currentPaymentViewDate = (currentBackupData && currentBackupData.analysis_start_date) ? new Date(currentBackupData.analysis_start_date) : new Date();
-        const analysisStartDate = new Date(currentPaymentViewDate);
+        const today = new Date();
+        const analysisStartDate = (currentBackupData && currentBackupData.analysis_start_date)
+            ? new Date(currentBackupData.analysis_start_date)
+            : new Date(today);
+        currentPaymentViewDate = today;
         const analysisEndDate = addMonths(new Date(analysisStartDate), (currentBackupData ? currentBackupData.analysis_duration : 12));
         paymentYearSelect.innerHTML = '';
         const startYear = Math.min(analysisStartDate.getUTCFullYear(), new Date().getUTCFullYear()) - 2;


### PR DESCRIPTION
## Summary
- default payment register view to current month and year

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846ef6182f88320b6e6ed566764f6eb