### PR TITLE
Resaltar periodo actual en flujo de caja

### DIFF
--- a/app.js
+++ b/app.js
@@ -2155,6 +2155,8 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
 
+        highlightCurrentPeriodColumn(periodicity, tableHeadEl, tableBodyEl, periodDates);
+
         if (periodicity === activeCashflowPeriodicity) {
             renderCashflowChart(periodDates, income_p, fixed_exp_p.map((val, idx) => val + var_exp_p[idx]), net_flow_p, end_bal_p);
         }
@@ -3049,6 +3051,22 @@ function getMondayOfWeek(year, week) {
             throw new Error("Invalid periodicity provided to getPeriodEndDate. Must be 'Mensual' or 'Semanal'.");
         }
         return periodEnd;
+    }
+
+    function highlightCurrentPeriodColumn(periodicity, headEl, bodyEl, periodDates) {
+        const today = new Date();
+        let idx = -1;
+        for (let i = 0; i < periodDates.length; i++) {
+            const start = periodDates[i];
+            const end = getPeriodEndDate(start, periodicity);
+            if (today >= start && today <= end) { idx = i; break; }
+        }
+        if (idx === -1) return;
+        const headerCells = headEl.querySelectorAll('th');
+        if (headerCells[idx + 1]) headerCells[idx + 1].classList.add('current-period');
+        Array.from(bodyEl.rows).forEach(row => {
+            if (row.cells[idx + 1]) row.cells[idx + 1].classList.add('current-period');
+        });
     }
 
 

--- a/style.css
+++ b/style.css
@@ -516,8 +516,8 @@ td.reimbursement-income {
 #cashflow-semanal-table td.current-period {
   background-image: repeating-linear-gradient(
     45deg,
-    rgba(56, 103, 214, 0.15) 0,
-    rgba(56, 103, 214, 0.15) 2px,
+    rgba(56, 103, 214, 0.10) 0,
+    rgba(56, 103, 214, 0.10) 2px,
     transparent 2px,
     transparent 4px
   );

--- a/style.css
+++ b/style.css
@@ -509,6 +509,20 @@ td.reimbursement-income {
 .text-orange { color: var(--text-orange) !important; }
 .small-text { font-size: 0.8em; color: var(--light-text); }
 
+/* Column highlight for el período actual */
+#cashflow-mensual-table th.current-period,
+#cashflow-mensual-table td.current-period,
+#cashflow-semanal-table th.current-period,
+#cashflow-semanal-table td.current-period {
+  background-image: repeating-linear-gradient(
+    45deg,
+    rgba(56, 103, 214, 0.15) 0,
+    rgba(56, 103, 214, 0.15) 2px,
+    transparent 2px,
+    transparent 4px
+  );
+}
+
 
 /* Mensaje de carga */
 #loading-message {


### PR DESCRIPTION
## Summary
- add style for highlighting current period column
- mark current period when rendering cashflow tables

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_6848913975a48320924efd2c968a362b