### PR TITLE
Add period subtabs to payments view

### DIFF
--- a/app.js
+++ b/app.js
@@ -2638,8 +2638,21 @@ document.addEventListener('DOMContentLoaded', () => {
             if (start > pEnd || (end && end < pStart)) return 0;
             const payDay = start.getUTCDate();
             if (periodicity === 'Semanal') {
-                const payDate = new Date(Date.UTC(pStart.getUTCFullYear(), pStart.getUTCMonth(), payDay));
-                return (payDate >= pStart && payDate <= pEnd && start <= payDate && (!end || end >= payDate)) ? 1 : 0;
+                const candidates = [];
+                const monthsToCheck = new Set([
+                    `${pStart.getUTCFullYear()}-${pStart.getUTCMonth()}`,
+                    `${pEnd.getUTCFullYear()}-${pEnd.getUTCMonth()}`
+                ]);
+                monthsToCheck.forEach(key => {
+                    const [y,m] = key.split('-').map(n=>parseInt(n));
+                    const daysInMonth = getDaysInMonth(y,m);
+                    const d = new Date(Date.UTC(y, m, Math.min(payDay, daysInMonth)));
+                    candidates.push(d);
+                });
+                for (const payDate of candidates) {
+                    if (payDate >= pStart && payDate <= pEnd && start <= payDate && (!end || end >= payDate)) return 1;
+                }
+                return 0;
             } else {
                 const year = pStart.getUTCFullYear();
                 const month = pStart.getUTCMonth();
@@ -2690,8 +2703,20 @@ document.addEventListener('DOMContentLoaded', () => {
             if (start > pEnd || (end && end < pStart)) return 0;
             const payDay = start.getUTCDate();
             if (periodicity === 'Semanal') {
-                const payDate = new Date(Date.UTC(pStart.getUTCFullYear(), pStart.getUTCMonth(), payDay));
-                return (payDate >= pStart && payDate <= pEnd && start <= payDate && (!end || end >= payDate)) ? 1 : 0;
+                const candidates = [];
+                const monthsToCheck = new Set([
+                    `${pStart.getUTCFullYear()}-${pStart.getUTCMonth()}`,
+                    `${pEnd.getUTCFullYear()}-${pEnd.getUTCMonth()}`
+                ]);
+                monthsToCheck.forEach(key => {
+                    const [y,m] = key.split('-').map(n=>parseInt(n));
+                    const daysInMonth = getDaysInMonth(y,m);
+                    candidates.push(new Date(Date.UTC(y, m, Math.min(payDay, daysInMonth))));
+                });
+                for (const payDate of candidates) {
+                    if (payDate >= pStart && payDate <= pEnd && start <= payDate && (!end || end >= payDate)) return 1;
+                }
+                return 0;
             } else {
                 const year = pStart.getUTCFullYear();
                 const month = pStart.getUTCMonth();

--- a/app.js
+++ b/app.js
@@ -2617,7 +2617,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function getExpenseOccurrencesInPeriod(expense, pStart, pEnd, periodicity, useInstant) {
-        if (!expense.start_date) return 0;
+        if (!expense || !expense.start_date || !(pStart instanceof Date) || !(pEnd instanceof Date) || pStart > pEnd) return 0;
         const baseStart = useInstant && expense.movement_date ? new Date(expense.movement_date) : new Date(expense.start_date);
         let start = baseStart;
         let end = expense.end_date ? new Date(expense.end_date) : null;
@@ -2692,7 +2692,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function getIncomeOccurrencesInPeriod(income, pStart, pEnd, periodicity) {
-        if (!income.start_date) return 0;
+        if (!income || !income.start_date || !(pStart instanceof Date) || !(pEnd instanceof Date) || pStart > pEnd) return 0;
         const start = new Date(income.start_date);
         const end = income.end_date ? new Date(income.end_date) : null;
         const freq = income.frequency || 'Mensual';

--- a/index.html
+++ b/index.html
@@ -309,7 +309,11 @@
             </div>
 
             <div id="registro-pagos" class="tab-content">
-                <h2 id="payments-tab-title">Registro de Pagos</h2>
+                <div class="subtabs-container" id="payments-subtabs">
+                    <button class="subtab-button active" data-parent="payments" data-period="Mensual">Mensual</button>
+                    <button class="subtab-button" data-parent="payments" data-period="Semanal">Semanal</button>
+                </div>
+                <h2 id="payments-tab-title">Registro de Pagos Mensual</h2>
                 <div class="payments-period-selector">
                     <button id="prev-period-button" title="Periodo Anterior">&lt;</button>
                     <select id="payment-year-select"></select>

--- a/index.html
+++ b/index.html
@@ -330,6 +330,7 @@
                                 <th>Categoría</th>
                                 <th>Tipo</th>
                                 <th>Real?</th>
+                                <th>Fecha</th>
                                 <th>Pagado</th>
                             </tr>
                         </thead>

--- a/test_app_logic.js
+++ b/test_app_logic.js
@@ -98,6 +98,80 @@ function getMondayOfWeek(year, week) {
 
 function getDaysInMonth(year, month) { return new Date(Date.UTC(year, month + 1, 0)).getUTCDate(); }
 
+function getExpenseOccurrencesInPeriod(expense, pStart, pEnd, periodicity, useInstant) {
+    if (!expense || !expense.start_date || !(pStart instanceof Date) || !(pEnd instanceof Date) || pStart > pEnd) return 0;
+    const baseStart = useInstant && expense.movement_date ? new Date(expense.movement_date) : new Date(expense.start_date);
+    let start = baseStart;
+    let end = expense.end_date ? new Date(expense.end_date) : null;
+    if (useInstant && expense.end_date && expense.movement_date) {
+        const diff = new Date(expense.start_date).getTime() - new Date(expense.movement_date).getTime();
+        end = new Date(new Date(expense.end_date).getTime() - diff);
+    }
+    const installments = parseInt(expense.installments || 1);
+    let freq = expense.frequency || 'Mensual';
+    if (installments > 1 && !useInstant) {
+        freq = 'Mensual';
+        end = addMonths(new Date(start), installments - 1);
+    }
+
+    if (freq === 'Único') {
+        return (start >= pStart && start <= pEnd) ? 1 : 0;
+    } else if (freq === 'Mensual') {
+        if (start > pEnd || (end && end < pStart)) return 0;
+        const payDay = start.getUTCDate();
+        if (periodicity === 'Semanal') {
+            const candidates = [];
+            const monthsToCheck = new Set([
+                `${pStart.getUTCFullYear()}-${pStart.getUTCMonth()}`,
+                `${pEnd.getUTCFullYear()}-${pEnd.getUTCMonth()}`
+            ]);
+            monthsToCheck.forEach(key => {
+                const [y, m] = key.split('-').map(n => parseInt(n));
+                const daysInMonth = getDaysInMonth(y, m);
+                candidates.push(new Date(Date.UTC(y, m, Math.min(payDay, daysInMonth))));
+            });
+            for (const payDate of candidates) {
+                if (payDate >= pStart && payDate <= pEnd && start <= payDate && (!end || end >= payDate)) return 1;
+            }
+            return 0;
+        } else {
+            const year = pStart.getUTCFullYear();
+            const month = pStart.getUTCMonth();
+            const daysInMonth = getDaysInMonth(year, month);
+            const payDate = new Date(Date.UTC(year, month, Math.min(payDay, daysInMonth)));
+            return (payDate >= pStart && payDate <= pEnd && start <= payDate && (!end || end >= payDate)) ? 1 : 0;
+        }
+    } else if (freq === 'Semanal') {
+        if (start > pEnd || (end && end < pStart)) return 0;
+        if (periodicity === 'Semanal') {
+            return 1;
+        } else {
+            let count = 0;
+            const payDow = start.getUTCDay();
+            let d = new Date(pStart.getTime());
+            while (d <= pEnd) {
+                if (d.getUTCDay() === payDow && d >= start && (!end || d <= end)) count++;
+                d.setUTCDate(d.getUTCDate() + 1);
+            }
+            return count;
+        }
+    } else if (freq === 'Bi-semanal') {
+        if (start > pEnd || (end && end < pStart)) return 0;
+        let count = 0;
+        let payDate = new Date(start.getTime());
+        while (payDate < pStart) {
+            payDate = addWeeks(payDate, 2);
+            if (end && payDate > end) return count;
+        }
+        while (payDate <= pEnd) {
+            if (!end || payDate <= end) count++;
+            payDate = addWeeks(payDate, 2);
+        }
+        return count;
+    }
+    return 0;
+}
+
 
 function getPeriodStartDate(date, periodicity) {
     const year = date.getUTCFullYear();
@@ -977,6 +1051,38 @@ runTest("calculateCashFlowData - Mixed Incomes and Installments", () => {
     assertEquals(100, r.var_exp_p[2], "Mixed - Mar installment");
     r = calculateCashFlowData({ ...data, use_instant_expenses: true });
     assertEquals(300, r.var_exp_p[0], "Mixed - Instant mode charges full amount Jan");
+});
+
+runTest("getExpenseOccurrencesInPeriod - Monthly across week boundary", () => {
+    const exp = { start_date: new Date(Date.UTC(2024,0,31)), frequency: "Mensual" };
+    const pStart = new Date(Date.UTC(2024,1,26));
+    const pEnd = new Date(Date.UTC(2024,2,3));
+    const occ = getExpenseOccurrencesInPeriod(exp, pStart, pEnd, "Semanal", false);
+    assertEquals(1, occ, "Monthly on 31 included in Feb 26-Mar 3 week");
+});
+
+runTest("getExpenseOccurrencesInPeriod - Weekly count in monthly view", () => {
+    const exp = { start_date: new Date(Date.UTC(2024,0,1)), frequency: "Semanal" };
+    const pStart = new Date(Date.UTC(2024,0,1));
+    const pEnd = new Date(Date.UTC(2024,0,31));
+    const occ = getExpenseOccurrencesInPeriod(exp, pStart, pEnd, "Mensual", false);
+    assertEquals(5, occ, "5 Mondays in Jan 2024");
+});
+
+runTest("getExpenseOccurrencesInPeriod - Bi-weekly count in monthly view", () => {
+    const exp = { start_date: new Date(Date.UTC(2024,0,1)), frequency: "Bi-semanal" };
+    const pStart = new Date(Date.UTC(2024,0,1));
+    const pEnd = new Date(Date.UTC(2024,0,31));
+    const occ = getExpenseOccurrencesInPeriod(exp, pStart, pEnd, "Mensual", false);
+    assertEquals(3, occ, "Bi-weekly Jan 2024 occurrences");
+});
+
+runTest("getExpenseOccurrencesInPeriod - Único weekly view", () => {
+    const exp = { start_date: new Date(Date.UTC(2024,1,14)), frequency: "Único" };
+    const pStart = new Date(Date.UTC(2024,1,12));
+    const pEnd = new Date(Date.UTC(2024,1,18));
+    const occ = getExpenseOccurrencesInPeriod(exp, pStart, pEnd, "Semanal", false);
+    assertEquals(1, occ, "Unique expense in same week");
 });
 // Ensure summarizeTests() is the last call.
 summarizeTests();


### PR DESCRIPTION
## Summary
- add subtab buttons for Registro Pagos
- support switching between mensual and semanal views with new function `setPaymentPeriodicity`
- keep month/week selectors in sync across views
- default payments periodicity to data's analysis periodicity

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_6849ced605008320a5efa63f92ca82bb