### PR TITLE
Add PDF summary print feature

### DIFF
--- a/app.js
+++ b/app.js
@@ -50,6 +50,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const instantExpenseToggle = document.getElementById('instant-expense-toggle');
     const usdClpInfoLabel = document.getElementById('usd-clp-info-label'); // Etiqueta para mostrar la tasa
     const applySettingsButton = document.getElementById('apply-settings-button');
+    const printSummaryButton = document.getElementById('print-summary-button');
     const creditCardForm = document.getElementById('credit-card-form');
     const creditCardNameInput = document.getElementById('credit-card-name');
     const creditCardCutoffInput = document.getElementById('credit-card-cutoff');
@@ -1380,6 +1381,10 @@ document.addEventListener('DOMContentLoaded', () => {
         renderBudgetsTable();
         renderBudgetSummaryTable();
     });
+
+    if (printSummaryButton) {
+        printSummaryButton.addEventListener('click', printCashflowSummary);
+    }
 
     if (creditCardForm) {
         creditCardCutoffInput.addEventListener('input', updateCreditCardExample);
@@ -3600,6 +3605,41 @@ function getMondayOfWeek(year, week) {
             }
         });
         return rows;
+    }
+
+    function printCashflowSummary() {
+        if (!window.jspdf || !window.jspdf.jsPDF || !window.jspdf.autoTable) {
+            alert('La librería jsPDF no está disponible');
+            return;
+        }
+
+        const { jsPDF } = window.jspdf;
+        const doc = new jsPDF({ orientation: 'landscape', unit: 'pt', format: 'letter' });
+
+        doc.text('Flujo de Caja - Mensual', 40, 30);
+        window.jspdf.autoTable(doc, {
+            html: '#cashflow-mensual-table',
+            startY: 40,
+            theme: 'grid',
+            styles: { fontSize: 8 },
+            headStyles: { fillColor: [220, 220, 220] },
+            horizontalPageBreak: true,
+            horizontalPageBreakRepeat: 0
+        });
+
+        doc.addPage('letter', 'landscape');
+        doc.text('Flujo de Caja - Semanal', 40, 30);
+        window.jspdf.autoTable(doc, {
+            html: '#cashflow-semanal-table',
+            startY: 40,
+            theme: 'grid',
+            styles: { fontSize: 8 },
+            headStyles: { fillColor: [220, 220, 220] },
+            horizontalPageBreak: true,
+            horizontalPageBreakRepeat: 0
+        });
+
+        doc.save('resumen_flujo_de_caja.pdf');
     }
 
     if (cashflowChartCanvas) {

--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/chartjs-plugin-zoom/2.0.1/chartjs-plugin-zoom.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.5.25/dist/jspdf.plugin.autotable.min.js"></script>
 </head>
 <body>
     <div class="container">
@@ -79,6 +81,7 @@
 
                         <button type="button" id="apply-settings-button" class="accent">Aplicar Ajustes y Recalcular</button>
                     </form>
+                    <button type="button" id="print-summary-button">Imprimir Resumen</button>
                 </div>
                 <div class="form-container settings-form-container" id="credit-card-settings-container">
                     <h3>Tarjetas de Crédito</h3>


### PR DESCRIPTION
## Summary
- add jsPDF and AutoTable scripts
- add button to print cashflow summary
- connect print button in app
- implement function to generate PDF for monthly and weekly cashflow tables

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_68654b4c388c8320b8cef0e9d83991c7