### PR TITLE
Add cash flow PDF summary

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/chartjs-plugin-zoom/2.0.1/chartjs-plugin-zoom.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.28/jspdf.plugin.autotable.min.js"></script>
 </head>
 <body>
     <div class="container">
@@ -77,9 +79,10 @@
                         
                         <p id="usd-clp-info-label" class="small-text informative-rate">1 USD = $CLP (Obteniendo...)</p>
 
-                        <button type="button" id="apply-settings-button" class="accent">Aplicar Ajustes y Recalcular</button>
-                    </form>
-                </div>
+                          <button type="button" id="apply-settings-button" class="accent">Aplicar Ajustes y Recalcular</button>
+                      </form>
+                      <button type="button" id="print-summary-button" class="accent">Imprimir Resumen</button>
+                  </div>
                 <div class="form-container settings-form-container" id="credit-card-settings-container">
                     <h3>Tarjetas de Crédito</h3>
                     <form id="credit-card-form">


### PR DESCRIPTION
## Summary
- add jsPDF and AutoTable scripts
- add "Imprimir Resumen" button in Ajustes
- implement PDF export of cash flow tables

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_68654b4c388c8320b8cef0e9d83991c7