### PR TITLE
Add cashflow PDF summary printing

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,6 +78,7 @@
                         <p id="usd-clp-info-label" class="small-text informative-rate">1 USD = $CLP (Obteniendo...)</p>
 
                         <button type="button" id="apply-settings-button" class="accent">Aplicar Ajustes y Recalcular</button>
+                        <button type="button" id="print-summary-button" class="accent">Imprimir Resumen</button>
                     </form>
                 </div>
                 <div class="form-container settings-form-container" id="credit-card-settings-container">
@@ -516,6 +517,8 @@
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-database.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.28/jspdf.plugin.autotable.min.js"></script>
 
     <script src="config.js"></script>
     <script src="app.js"></script>


### PR DESCRIPTION
## Summary
- add **Imprimir Resumen** button to Ajustes tab
- include jsPDF and AutoTable libraries
- implement `printCashflowSummary` with helper utilities to split wide tables across PDF pages

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_68654b4c388c8320b8cef0e9d83991c7