### PR TITLE
Add popup with formula details for cashflow cells

### DIFF
--- a/index.html
+++ b/index.html
@@ -490,6 +490,13 @@
                     </div>
                 </div>
             </div>
+            <div id="formula-modal" class="modal" style="display:none;">
+                <div class="modal-content">
+                    <span id="formula-modal-close" class="modal-close">&times;</span>
+                    <h3 id="formula-modal-title"></h3>
+                    <div id="formula-modal-body"></div>
+                </div>
+            </div>
             <div id="import-expenses-modal" class="modal" style="display:none;">
                 <div class="modal-content">
                     <span id="import-expenses-modal-close" class="modal-close">&times;</span>


### PR DESCRIPTION
## Summary
- introduce Formula modal markup
- store cashflow table data for lookup
- add dataset info to table cells and listener to open new modal
- calculate and display formula breakdown in modal

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_68668e209f388320bcd296bedf244f8d