### PR TITLE
Add cell detail popup for cashflow tables

### DIFF
--- a/index.html
+++ b/index.html
@@ -488,6 +488,11 @@
                             <tbody></tbody>
                         </table>
                     </div>
+            <div id="cashflow-detail-modal" class="modal" style="display:none;">
+                <div class="modal-content">
+                    <span id="cashflow-detail-modal-close" class="modal-close">&times;</span>
+                    <h3 id="cashflow-detail-modal-title"></h3>
+                    <div id="cashflow-detail-modal-body"></div>
                 </div>
             </div>
             <div id="import-expenses-modal" class="modal" style="display:none;">

--- a/style.css
+++ b/style.css
@@ -1300,3 +1300,6 @@ td.reimbursement-income {
 @media (min-width: 769px) {
     .desktop-only { display: inline-block; }
 }
+
+.cashflow-clickable { cursor: pointer; }
+.cashflow-clickable:hover { background-color: var(--row-hover-bg); }


### PR DESCRIPTION
## Summary
- make cells in cashflow tables clickable
- show a modal with calculation details for the selected period
- style clickable cells

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_68668e209f388320bcd296bedf244f8d