### PR TITLE
Enable detail popup on cashflow cells

### DIFF
--- a/style.css
+++ b/style.css
@@ -508,6 +508,7 @@ td.reimbursement-income {
 .text-green { color: var(--text-green) !important; }
 .text-orange { color: var(--text-orange) !important; }
 .small-text { font-size: 0.8em; color: var(--light-text); }
+.cf-value { cursor: pointer; }
 
 /* Column highlight for el período actual */
 #cashflow-mensual-table th.current-period,


### PR DESCRIPTION
## Summary
- cache cashflow calculations and attach click handlers on table cells
- open modal with the transaction math when clicking a cashflow value
- show pointer cursor on clickable cashflow cells

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_68668e209f388320bcd296bedf244f8d