### PR TITLE
Implement hover details for cashflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -1288,6 +1288,23 @@ td.reimbursement-income {
 .duplicate-row {
     background-color: var(--alt-row-bg);
 }
+# Tooltip para detalles de celdas en flujo de caja
+.cell-tooltip {
+    position: absolute;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    padding: 6px;
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    display: none;
+    z-index: 2000;
+    max-width: 250px;
+    font-size: 0.85rem;
+    pointer-events: none;
+}
+.cashflow-cell[data-detail] {
+    cursor: help;
+}
 #import-expenses-modal .modal-content {
     width: 100%;
     height: 100%;

--- a/test_app_logic.js
+++ b/test_app_logic.js
@@ -267,7 +267,7 @@ function getPeriodEndDate(date, periodicity) {
 }
 
 // calculateCashFlowData (Updated to reflect app.js state after Turn 11 fixes)
-function calculateCashFlowData(data) {
+function calculateCashFlowData(data, withDetails = false) {
     const startDate = data.analysis_start_date; 
     const duration = parseInt(data.analysis_duration, 10); 
     const periodicity = data.analysis_periodicity;


### PR DESCRIPTION
## Summary
- add tooltip styles for cashflow tables
- extend `calculateCashFlowData` to optionally provide detail info
- display breakdown on desktop when hovering table cells
- update helper script with new parameter

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_6866a85d73308320868248dacf75953e