### PR TITLE
Add hover popups for cashflow cells

### DIFF
--- a/style.css
+++ b/style.css
@@ -775,6 +775,24 @@ td.reimbursement-income {
     color: var(--light-text);
 }
 
+/* Popup para detalles en las celdas de flujo de caja */
+.cashflow-cell-popup {
+    position: absolute;
+    z-index: 2000;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    padding: 8px;
+    max-width: 260px;
+    font-size: 0.85rem;
+    line-height: 1.3;
+    display: none;
+}
+.cashflow-cell-popup.show {
+    display: block;
+}
+
 
 /* Estilos para Pestaña Baby Steps */
 .baby-steps-layout {


### PR DESCRIPTION
## Summary
- add tooltip popup styles for cashflow tables
- compute per-period transaction details and store in cell attributes
- on desktop, show popup after hovering a cell for one second
- hide popup on outside click

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_6866a85d73308320868248dacf75953e