### PR TITLE
Implement cashflow breakdown tooltip on desktop

### DIFF
--- a/style.css
+++ b/style.css
@@ -1249,6 +1249,19 @@ td.reimbursement-income {
     cursor: pointer;
 }
 
+/* Popup de desglose para celdas de flujo de caja (solo escritorio) */
+.cell-breakdown-popup {
+    position: absolute;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    padding: 8px;
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    z-index: 1100;
+    font-size: 0.85rem;
+    max-width: 250px;
+}
+
 #expense-drop-zone {
     border: 2px dashed var(--border-color);
     padding: 20px;


### PR DESCRIPTION
## Summary
- add CSS for cell breakdown popup
- store cashflow table data for future reference
- expose dataset and mouse events for cashflow table cells
- implement JS logic to show breakdown popup on hover for desktop

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_6866a85d73308320868248dacf75953e