### PR TITLE
Add Gemini AI integration for expense import

### DIFF
--- a/app.js
+++ b/app.js
@@ -113,9 +113,17 @@ document.addEventListener('DOMContentLoaded', () => {
     const importTableContainer = document.getElementById('import-table-container');
     const bankProfileSelect = document.getElementById('import-bank-profile');
     const mergeExpensesButton = document.getElementById('merge-expenses-button');
+    const geminiStatus = document.getElementById('gemini-status');
+    const geminiChat = document.getElementById('gemini-chat');
+    const geminiMessagesDiv = document.getElementById('gemini-messages');
+    const geminiChatInput = document.getElementById('gemini-chat-input');
+    const geminiSendButton = document.getElementById('gemini-send-button');
     let editingExpenseIndex = null;
     let parsedImportData = [];
     let importHeaders = [];
+    let aiDuplicateFlags = [];
+    let geminiAvailable = false;
+    let geminiChatHistory = [];
     const bankProfiles = {
         falabella: {
             matchFileName: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.xlsx$/i,
@@ -1876,6 +1884,8 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- IMPORTACIÓN MASIVA DE GASTOS ---
     function showImportExpensesModal() {
         if (importExpensesModal) importExpensesModal.style.display = 'flex';
+        if (geminiStatus) geminiStatus.textContent = 'IA: verificando disponibilidad...';
+        checkGeminiAvailability();
     }
     function closeImportExpensesModal() {
         if (importExpensesModal) importExpensesModal.style.display = 'none';
@@ -1886,6 +1896,8 @@ document.addEventListener('DOMContentLoaded', () => {
         if (bankProfileSelect) bankProfileSelect.value = 'auto';
         const bankProfileDiv = document.getElementById('bank-profile');
         if (bankProfileDiv) bankProfileDiv.style.display = 'none';
+        geminiChatHistory = [];
+        renderGeminiMessages();
     }
     function parseExcelDate(val) {
         if (val === undefined || val === null) return null;
@@ -1916,6 +1928,93 @@ document.addEventListener('DOMContentLoaded', () => {
             const expDate = exp.movement_date ? getISODateString(new Date(exp.movement_date)) : (exp.start_date ? getISODateString(new Date(exp.start_date)) : '');
             return expDate === dateStr && exp.name === name && parseFloat(exp.amount) === parseFloat(amount);
         });
+    }
+
+    async function geminiRequest(contents) {
+        const url = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent?key=${GEMINI_API_KEY}`;
+        const resp = await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ contents })
+        });
+        if (!resp.ok) throw new Error('Gemini API error');
+        return resp.json();
+    }
+
+    async function checkGeminiAvailability() {
+        try {
+            await geminiRequest([{ parts: [{ text: 'ping' }] }]);
+            geminiAvailable = true;
+        } catch (e) {
+            geminiAvailable = false;
+        }
+        if (geminiStatus) geminiStatus.textContent = geminiAvailable ? 'IA disponible' : 'IA no disponible';
+        if (geminiChat) geminiChat.style.display = geminiAvailable ? 'block' : 'none';
+    }
+
+    async function classifyDuplicatesWithAI(rows) {
+        if (!geminiAvailable) { return rows.map(r => false); }
+        const existing = (currentBackupData.expenses || []).map(exp => ({
+            name: exp.name,
+            amount: parseFloat(exp.amount),
+            date: exp.movement_date ? getISODateString(new Date(exp.movement_date)) : (exp.start_date ? getISODateString(new Date(exp.start_date)) : '')
+        }));
+        const imported = rows.map(r => ({ name: r.desc, amount: parseFloat(r.amount), date: r.date }));
+        const systemMsg = {
+            parts: [{ text: 'La aplicación gestiona gastos con los campos name, amount, category, frequency, start_date, end_date, movement_date, payment_method y installments. Determina si un gasto importado ya existe comparando nombre, fecha y monto. Responde con un array JSON de valores true/false para cada gasto importado.' }]
+        };
+        const userMsg = {
+            parts: [{ text: `Existentes: ${JSON.stringify(existing)}\nImportados: ${JSON.stringify(imported)}` }]
+        };
+        try {
+            const data = await geminiRequest([systemMsg, userMsg]);
+            const text = data.candidates && data.candidates[0] && data.candidates[0].content && data.candidates[0].content.parts[0].text;
+            const arr = JSON.parse(text);
+            return Array.isArray(arr) ? arr.map(v => !!v) : rows.map(() => false);
+        } catch (e) {
+            return rows.map(() => false);
+        }
+    }
+
+    async function updateAIDuplicates() {
+        const dateCol = mapDateSelect.value;
+        const descCol = mapDescSelect.value;
+        const amountCol = mapAmountSelect.value;
+        if (!dateCol || !descCol || !amountCol) { aiDuplicateFlags = []; return; }
+        const rows = parsedImportData.map(r => ({
+            desc: r[descCol] !== undefined ? String(r[descCol]) : '',
+            amount: r[amountCol],
+            date: (function(){const d=parseExcelDate(r[dateCol]);return d?getISODateString(d):'';})()
+        }));
+        aiDuplicateFlags = await classifyDuplicatesWithAI(rows);
+    }
+
+    async function sendGeminiMessage() {
+        const txt = geminiChatInput.value.trim();
+        if (!txt) return;
+        geminiChatInput.value = '';
+        geminiChatHistory.push({ role: 'user', parts: [{ text: txt }] });
+        renderGeminiMessages();
+        try {
+            const data = await geminiRequest([ { parts: [{ text: 'La aplicación gestiona gastos con los campos name, amount, category, frequency, start_date, end_date, movement_date, payment_method y installments.' }] }, ...geminiChatHistory ]);
+            const reply = data.candidates && data.candidates[0] && data.candidates[0].content && data.candidates[0].content.parts[0].text;
+            geminiChatHistory.push({ role: 'model', parts: [{ text: reply }] });
+            renderGeminiMessages();
+        } catch (e) {
+            geminiChatHistory.push({ role: 'model', parts: [{ text: 'Error al contactar la IA.' }] });
+            renderGeminiMessages();
+        }
+    }
+
+    function renderGeminiMessages() {
+        if (!geminiMessagesDiv) return;
+        geminiMessagesDiv.innerHTML = '';
+        geminiChatHistory.forEach(m => {
+            const p = document.createElement('p');
+            p.textContent = (m.role === 'user' ? 'Tú: ' : 'IA: ') + m.parts[0].text;
+            geminiMessagesDiv.appendChild(p);
+        });
+        geminiMessagesDiv.scrollTop = geminiMessagesDiv.scrollHeight;
     }
     function createCategorySelect() {
         const sel = document.createElement('select');
@@ -1976,7 +2075,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const dateStr = dateObj ? getISODateString(dateObj) : '';
             const desc = row[descCol] !== undefined ? String(row[descCol]) : '';
             const amt = row[amountCol];
-            const isDup = checkExpenseDuplicate(desc, dateStr, parseFloat(amt));
+            const isDup = aiDuplicateFlags[idx] === true ? true : (!geminiAvailable && checkExpenseDuplicate(desc, dateStr, parseFloat(amt)));
             const tr = document.createElement('tr');
             if (isDup) tr.classList.add('duplicate-row');
             const chkCell = tr.insertCell();
@@ -2014,6 +2113,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }
             if (bankProfileSelect) bankProfileSelect.value = detected;
             renderMappingSelectors();
+            updateAIDuplicates().then(renderImportTable);
         };
         reader.readAsArrayBuffer(file);
     }
@@ -2028,9 +2128,9 @@ document.addEventListener('DOMContentLoaded', () => {
         expenseDropZone.addEventListener('drop', e => { e.preventDefault(); expenseDropZone.classList.remove('dragover'); if (e.dataTransfer.files[0]) handleExpenseFile(e.dataTransfer.files[0]); });
     }
     if (expenseFileInput) expenseFileInput.addEventListener('change', e => { if (e.target.files[0]) handleExpenseFile(e.target.files[0]); });
-    if (mapDateSelect) mapDateSelect.addEventListener('change', renderImportTable);
-    if (mapDescSelect) mapDescSelect.addEventListener('change', renderImportTable);
-    if (mapAmountSelect) mapAmountSelect.addEventListener('change', renderImportTable);
+    if (mapDateSelect) mapDateSelect.addEventListener('change', () => { updateAIDuplicates().then(renderImportTable); });
+    if (mapDescSelect) mapDescSelect.addEventListener('change', () => { updateAIDuplicates().then(renderImportTable); });
+    if (mapAmountSelect) mapAmountSelect.addEventListener('change', () => { updateAIDuplicates().then(renderImportTable); });
     if (bankProfileSelect) bankProfileSelect.addEventListener('change', () => applyBankProfile(bankProfileSelect.value));
     if (mergeExpensesButton) mergeExpensesButton.addEventListener('click', () => {
         const dateCol = mapDateSelect.value;
@@ -2056,6 +2156,8 @@ document.addEventListener('DOMContentLoaded', () => {
         renderCashflowTable();
         closeImportExpensesModal();
     });
+    if (geminiSendButton) geminiSendButton.addEventListener('click', sendGeminiMessage);
+    if (geminiChatInput) geminiChatInput.addEventListener('keydown', e => { if(e.key==='Enter'){ e.preventDefault(); sendGeminiMessage(); } });
 
     // --- LÓGICA PESTAÑA PRESUPUESTOS ---
     function resetBudgetForm() {

--- a/config.js
+++ b/config.js
@@ -11,6 +11,10 @@ const firebaseConfig = {
     appId: "1:363279849526:web:71bc23cceb2e24a3d4a097"
 };
 
+// API de Google Gemini
+const GEMINI_API_KEY = "AIzaSyB_IazCUbRrYp96Em5s3z5MXXfBEbCC86o";
+const GEMINI_MODEL = "gemini-2.5-flash";
+
 // Mapea los UID de Firebase a las sub-rutas de datos dentro de /users
 // Modifica este objeto según tus propios usuarios
 const USER_PATHS = {

--- a/index.html
+++ b/index.html
@@ -508,6 +508,14 @@
                         <label>Monto<select id="map-amount"></select></label>
                     </div>
                     <div id="import-table-container"></div>
+                    <div id="gemini-status" class="ai-status">IA: verificando disponibilidad...</div>
+                    <div id="gemini-chat" class="ai-chat" style="display:none;">
+                        <div id="gemini-messages" class="messages"></div>
+                        <div class="chat-input">
+                            <input type="text" id="gemini-chat-input" placeholder="Escribe un mensaje...">
+                            <button type="button" id="gemini-send-button">Enviar</button>
+                        </div>
+                    </div>
                     <button type="button" id="merge-expenses-button" class="accent">Unir</button>
                 </div>
             </div>

--- a/style.css
+++ b/style.css
@@ -1323,3 +1323,30 @@ td.reimbursement-income {
 }
 .breakdown-popup li { margin: 2px 0; }
 
+/* Gemini AI integration */
+.ai-status {
+    margin-top: 10px;
+    font-size: 0.9rem;
+}
+.ai-chat {
+    border: 1px solid var(--border-color);
+    margin-top: 10px;
+    padding: 5px;
+    max-height: 200px;
+    display: flex;
+    flex-direction: column;
+}
+.ai-chat .messages {
+    flex: 1;
+    overflow-y: auto;
+    font-size: 0.9rem;
+}
+.ai-chat .chat-input {
+    display: flex;
+    gap: 4px;
+    margin-top: 4px;
+}
+.ai-chat input {
+    flex: 1;
+}
+


### PR DESCRIPTION
## Summary
- integrate Google Gemini API key in config
- add AI status indicator and chat box to import wizard
- style AI chat components
- implement functions to call Gemini API for duplicate detection and chat
- hook into import logic to check duplicates via Gemini

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_686700dcac3083208a82c5e9eb11383a