### PR TITLE
Add manual AI import step

### DIFF
--- a/app.js
+++ b/app.js
@@ -113,15 +113,59 @@ document.addEventListener('DOMContentLoaded', () => {
     const importTableContainer = document.getElementById('import-table-container');
     const bankProfileSelect = document.getElementById('import-bank-profile');
     const mergeExpensesButton = document.getElementById('merge-expenses-button');
+    const processImportButton = document.getElementById('process-import-button');
+    const aiStatusLabel = document.getElementById('ai-status');
+    const aiChatContainer = document.getElementById('ai-chat-container');
+    const aiChatMessages = document.getElementById('ai-chat-messages');
+    const aiChatInput = document.getElementById('ai-chat-input');
+    const aiChatSend = document.getElementById('ai-chat-send');
     let editingExpenseIndex = null;
     let parsedImportData = [];
     let importHeaders = [];
+    let aiAvailable = false;
+    let aiDuplicateIndexes = new Set();
     const bankProfiles = {
         falabella: {
             matchFileName: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.xlsx$/i,
             columns: { date: 'FECHA', desc: 'DESCRIPCION', amount: 'MONTO' }
         }
     };
+
+    const GEMINI_CONTEXT = `Eres un asistente para la aplicación financiera que administra gastos e ingresos.
+Cuando recibes encabezados de un archivo Excel con algunas filas de ejemplo debes responder solo un JSON con las claves "date", "description" y "amount" indicando el nombre exacto de la columna de fecha, descripción y monto. Usa cadena vacía si no puedes determinar alguna columna.
+También puedes recibir listas de gastos para identificar duplicados y responder un arreglo JSON con los índices que ya existen.
+En general un gasto coincide si fecha, descripción y monto son iguales, pero si solo coinciden fecha y monto probablemente sea el mismo movimiento.
+Si encuentras columnas de monto y número de cuota, el webapp usa el monto total y un campo "installments". Considera el total y revisa si existe un movimiento previo con los mismos datos pero con número de cuota uno menor para asociar correctamente las cuotas.`;
+
+    async function geminiRequest(text) {
+        const body = { contents: [ { parts: [ { text: GEMINI_CONTEXT + "\n" + text } ] } ] };
+        const res = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${GEMINI_API_KEY}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body)
+        });
+        if (!res.ok) throw new Error('Gemini request failed');
+        const data = await res.json();
+        return (((data.candidates || [])[0] || {}).content || {}).parts[0]?.text || '';
+    }
+
+    async function checkGeminiAvailability() {
+        try {
+            await geminiRequest('Di \"ok\"');
+            aiAvailable = true;
+            if (aiStatusLabel) aiStatusLabel.textContent = 'IA: disponible';
+        } catch(e) {
+            aiAvailable = false;
+            if (aiStatusLabel) aiStatusLabel.textContent = 'IA: no disponible';
+        }
+    }
+
+    async function analyzeDuplicatesWithAI(list) {
+        if (!aiAvailable) return [];
+        const prompt = `Lista actual: ${JSON.stringify(currentBackupData.expenses.map(e => ({name: e.name, date: e.movement_date ? getISODateString(new Date(e.movement_date)) : (e.start_date ? getISODateString(new Date(e.start_date)) : ''), amount: parseFloat(e.amount)})))}. Nuevos gastos: ${JSON.stringify(list)}. Devuelve solo un array JSON de indices de nuevos gastos que ya existen.`;
+        const reply = await geminiRequest(prompt);
+        try { return JSON.parse(reply); } catch { return []; }
+    }
 
     // --- BLOQUEO DE EDICIÓN ---
     let editLockAcquired = false;
@@ -1876,16 +1920,22 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- IMPORTACIÓN MASIVA DE GASTOS ---
     function showImportExpensesModal() {
         if (importExpensesModal) importExpensesModal.style.display = 'flex';
+        aiDuplicateIndexes.clear();
+        if (aiStatusLabel) aiStatusLabel.textContent = 'IA: verificando...';
+        checkGeminiAvailability();
+        if (processImportButton) { processImportButton.style.display = 'none'; processImportButton.disabled = false; }
     }
     function closeImportExpensesModal() {
         if (importExpensesModal) importExpensesModal.style.display = 'none';
         parsedImportData = [];
         importHeaders = [];
+        aiDuplicateIndexes.clear();
         if (importTableContainer) importTableContainer.innerHTML = '';
         if (columnMappingDiv) columnMappingDiv.style.display = 'none';
         if (bankProfileSelect) bankProfileSelect.value = 'auto';
         const bankProfileDiv = document.getElementById('bank-profile');
         if (bankProfileDiv) bankProfileDiv.style.display = 'none';
+        if (processImportButton) { processImportButton.style.display = 'none'; processImportButton.disabled = false; }
     }
     function parseExcelDate(val) {
         if (val === undefined || val === null) return null;
@@ -1914,7 +1964,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function checkExpenseDuplicate(name, dateStr, amount) {
         return (currentBackupData.expenses || []).some(exp => {
             const expDate = exp.movement_date ? getISODateString(new Date(exp.movement_date)) : (exp.start_date ? getISODateString(new Date(exp.start_date)) : '');
-            return expDate === dateStr && exp.name === name && parseFloat(exp.amount) === parseFloat(amount);
+            return expDate === dateStr && parseFloat(exp.amount) === parseFloat(amount);
         });
     }
     function createCategorySelect() {
@@ -1941,6 +1991,7 @@ document.addEventListener('DOMContentLoaded', () => {
             mapDateSelect.value = importHeaders.find(h => /fecha/i.test(h)) || '';
             mapDescSelect.value = importHeaders.find(h => /desc/i.test(h)) || '';
             mapAmountSelect.value = importHeaders.find(h => /monto/i.test(h)) || '';
+            if (profileKey === 'auto') requestAIMapping();
         }
         renderImportTable();
     }
@@ -1957,8 +2008,9 @@ document.addEventListener('DOMContentLoaded', () => {
         columnMappingDiv.style.display = 'flex';
         const bankProfileDiv = document.getElementById('bank-profile');
         if (bankProfileDiv) bankProfileDiv.style.display = 'flex';
+        requestAIDuplicates();
     }
-    function renderImportTable() {
+function renderImportTable() {
         if (!importTableContainer) return;
         importTableContainer.innerHTML = '';
         const dateCol = mapDateSelect.value;
@@ -1976,7 +2028,9 @@ document.addEventListener('DOMContentLoaded', () => {
             const dateStr = dateObj ? getISODateString(dateObj) : '';
             const desc = row[descCol] !== undefined ? String(row[descCol]) : '';
             const amt = row[amountCol];
-            const isDup = checkExpenseDuplicate(desc, dateStr, parseFloat(amt));
+            const localDup = checkExpenseDuplicate(desc, dateStr, parseFloat(amt));
+            const aiDup = aiDuplicateIndexes.has(idx);
+            const isDup = localDup || aiDup;
             const tr = document.createElement('tr');
             if (isDup) tr.classList.add('duplicate-row');
             const chkCell = tr.insertCell();
@@ -1991,6 +2045,57 @@ document.addEventListener('DOMContentLoaded', () => {
         });
         table.appendChild(tbody);
         importTableContainer.appendChild(table);
+    }
+
+    async function requestAIMapping() {
+        if (!aiAvailable || !parsedImportData.length) return;
+        const sample = parsedImportData.slice(0, 3).map(row => {
+            const obj = {};
+            importHeaders.forEach(h => { obj[h] = row[h]; });
+            return obj;
+        });
+        const prompt = `Encabezados: ${JSON.stringify(importHeaders)}. Ejemplos: ${JSON.stringify(sample)}. Devuelve solo un JSON con las claves \"date\", \"description\" y \"amount\" indicando la columna correspondiente`;
+        try {
+            const reply = await geminiRequest(prompt);
+            const mapping = JSON.parse(reply);
+            if (mapping.date && importHeaders.includes(mapping.date)) mapDateSelect.value = mapping.date;
+            if (mapping.description && importHeaders.includes(mapping.description)) mapDescSelect.value = mapping.description;
+            if (mapping.amount && importHeaders.includes(mapping.amount)) mapAmountSelect.value = mapping.amount;
+        } catch(e) {
+            console.error('AI mapping error', e);
+        }
+        renderImportTable();
+        requestAIDuplicates();
+    }
+
+    async function requestAIDuplicates() {
+        if (!aiAvailable) { renderImportTable(); return; }
+        const dateCol = mapDateSelect.value;
+        const descCol = mapDescSelect.value;
+        const amountCol = mapAmountSelect.value;
+        if (!dateCol || !descCol || !amountCol) { renderImportTable(); return; }
+        const list = parsedImportData.map((row, idx) => {
+            const dateObj = parseExcelDate(row[dateCol]);
+            const dateStr = dateObj ? getISODateString(dateObj) : '';
+            const desc = row[descCol] !== undefined ? String(row[descCol]) : '';
+            const amt = parseFloat(row[amountCol] || 0);
+            return { index: idx, name: desc, date: dateStr, amount: amt };
+        });
+        try {
+            const dups = await analyzeDuplicatesWithAI(list);
+            aiDuplicateIndexes = new Set(dups);
+        } catch(e) {
+            console.error(e);
+            aiDuplicateIndexes = new Set();
+        }
+        renderImportTable();
+    }
+
+    function processImportFile() {
+        if (!parsedImportData.length) return;
+        if (processImportButton) { processImportButton.disabled = true; }
+        renderMappingSelectors();
+        if (processImportButton) processImportButton.style.display = 'none';
     }
     function handleExpenseFile(file) {
         const reader = new FileReader();
@@ -2013,7 +2118,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             }
             if (bankProfileSelect) bankProfileSelect.value = detected;
-            renderMappingSelectors();
+            if (processImportButton) processImportButton.style.display = 'block';
         };
         reader.readAsArrayBuffer(file);
     }
@@ -2028,10 +2133,11 @@ document.addEventListener('DOMContentLoaded', () => {
         expenseDropZone.addEventListener('drop', e => { e.preventDefault(); expenseDropZone.classList.remove('dragover'); if (e.dataTransfer.files[0]) handleExpenseFile(e.dataTransfer.files[0]); });
     }
     if (expenseFileInput) expenseFileInput.addEventListener('change', e => { if (e.target.files[0]) handleExpenseFile(e.target.files[0]); });
-    if (mapDateSelect) mapDateSelect.addEventListener('change', renderImportTable);
-    if (mapDescSelect) mapDescSelect.addEventListener('change', renderImportTable);
-    if (mapAmountSelect) mapAmountSelect.addEventListener('change', renderImportTable);
-    if (bankProfileSelect) bankProfileSelect.addEventListener('change', () => applyBankProfile(bankProfileSelect.value));
+    if (processImportButton) processImportButton.addEventListener('click', processImportFile);
+    if (mapDateSelect) mapDateSelect.addEventListener('change', requestAIDuplicates);
+    if (mapDescSelect) mapDescSelect.addEventListener('change', requestAIDuplicates);
+    if (mapAmountSelect) mapAmountSelect.addEventListener('change', requestAIDuplicates);
+    if (bankProfileSelect) bankProfileSelect.addEventListener('change', () => { applyBankProfile(bankProfileSelect.value); requestAIDuplicates(); });
     if (mergeExpensesButton) mergeExpensesButton.addEventListener('click', () => {
         const dateCol = mapDateSelect.value;
         const descCol = mapDescSelect.value;
@@ -2056,6 +2162,28 @@ document.addEventListener('DOMContentLoaded', () => {
         renderCashflowTable();
         closeImportExpensesModal();
     });
+
+    async function sendAIChat() {
+        const text = aiChatInput.value.trim();
+        if (!text) return;
+        const msgDiv = document.createElement('div');
+        msgDiv.textContent = 'Tú: ' + text;
+        aiChatMessages.appendChild(msgDiv);
+        aiChatInput.value = '';
+        try {
+            const reply = await geminiRequest(text);
+            const rDiv = document.createElement('div');
+            rDiv.textContent = 'IA: ' + reply;
+            aiChatMessages.appendChild(rDiv);
+            aiChatMessages.scrollTop = aiChatMessages.scrollHeight;
+        } catch(e) {
+            const errDiv = document.createElement('div');
+            errDiv.textContent = 'IA sin respuesta';
+            aiChatMessages.appendChild(errDiv);
+        }
+    }
+    if (aiChatSend) aiChatSend.addEventListener('click', sendAIChat);
+    if (aiChatInput) aiChatInput.addEventListener('keydown', e => { if (e.key === 'Enter') { e.preventDefault(); sendAIChat(); } });
 
     // --- LÓGICA PESTAÑA PRESUPUESTOS ---
     function resetBudgetForm() {

--- a/config.js
+++ b/config.js
@@ -30,6 +30,9 @@ firebase.initializeApp(firebaseConfig);
 const auth = firebase.auth();
 const database = firebase.database();
 
+// Clave para acceder a la API de Gemini
+const GEMINI_API_KEY = "AIzaSyB_IazCUbRrYp96Em5s3z5MXXfBEbCC86o";
+
 // --- Funciones de utilidad ---
 
 /**

--- a/index.html
+++ b/index.html
@@ -494,8 +494,10 @@
                 <div class="modal-content">
                     <span id="import-expenses-modal-close" class="modal-close">&times;</span>
                     <h3>Importar Gastos desde Excel</h3>
+                    <p id="ai-status">IA: verificando...</p>
                     <div id="expense-drop-zone">Arrastra el archivo .xlsx aquí o haz clic para seleccionar</div>
                     <input type="file" id="expense-file-input" accept=".xlsx,.xls" style="display:none;">
+                    <button type="button" id="process-import-button" class="accent" style="display:none;">Procesar Archivo</button>
                     <div id="bank-profile" style="display:none;">
                         <label>Perfil<select id="import-bank-profile">
                             <option value="auto">Automático</option>
@@ -509,6 +511,13 @@
                     </div>
                     <div id="import-table-container"></div>
                     <button type="button" id="merge-expenses-button" class="accent">Unir</button>
+                    <div id="ai-chat-container">
+                        <div id="ai-chat-messages" class="chat-messages"></div>
+                        <div class="chat-input-group">
+                            <input type="text" id="ai-chat-input" placeholder="Pregunta a la IA">
+                            <button type="button" id="ai-chat-send">Enviar</button>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/style.css
+++ b/style.css
@@ -1323,3 +1323,27 @@ td.reimbursement-income {
 }
 .breakdown-popup li { margin: 2px 0; }
 
+#ai-chat-container {
+    border-top: 1px solid var(--border-color);
+    margin-top: 10px;
+    padding-top: 10px;
+}
+
+.chat-messages {
+    height: 120px;
+    overflow-y: auto;
+    border: 1px solid var(--border-color);
+    padding: 5px;
+    margin-bottom: 5px;
+    background-color: var(--input-bg);
+}
+
+.chat-input-group {
+    display: flex;
+    gap: 5px;
+}
+
+.chat-input-group input {
+    flex: 1;
+}
+


### PR DESCRIPTION
## Summary
- require pressing a new button to process imported expenses
- enhance Gemini context with duplicate and installment guidance
- treat duplicates if date and amount match

## Testing
- `node test_app_logic.js`


------
https://chatgpt.com/codex/tasks/task_e_686700dcac3083208a82c5e9eb11383a