### PR TITLE
Improve expense import AI

### DIFF
--- a/app.js
+++ b/app.js
@@ -113,15 +113,59 @@ document.addEventListener('DOMContentLoaded', () => {
     const importTableContainer = document.getElementById('import-table-container');
     const bankProfileSelect = document.getElementById('import-bank-profile');
     const mergeExpensesButton = document.getElementById('merge-expenses-button');
+    const analyzeImportButton = document.getElementById("analyze-import-button");
+    const aiStatusLabel = document.getElementById('ai-status');
+    const aiChatContainer = document.getElementById('ai-chat-container');
+    const aiChatMessages = document.getElementById('ai-chat-messages');
+    const aiChatInput = document.getElementById('ai-chat-input');
+    const aiChatSend = document.getElementById('ai-chat-send');
     let editingExpenseIndex = null;
     let parsedImportData = [];
     let importHeaders = [];
+    let aiAvailable = false;
+    let aiDuplicateIndexes = new Set();
+    let selectedExpenseFile = null;
     const bankProfiles = {
         falabella: {
             matchFileName: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.xlsx$/i,
             columns: { date: 'FECHA', desc: 'DESCRIPCION', amount: 'MONTO' }
         }
     };
+
+    const GEMINI_CONTEXT = `Eres un asistente para la aplicacion financiera que administra gastos e ingresos.
+Cuando recibes encabezados de un archivo Excel con filas de ejemplo debes responder solo un JSON con las claves "date", "description" y "amount" indicando la columna exacta de fecha, descripcion y monto (usa cadena vacia si no sabes).
+Tambien puedes recibir listas de gastos para indicar duplicados. Considera duplicado si coinciden fecha y monto aunque la descripcion cambie.
+Si hay columnas de monto total y de cuotas, usa el monto total y registra el numero de cuotas. Al buscar duplicados con cuotas verifica si existe un movimiento previo con numero de cuota uno menor y datos iguales.
+Responde siempre solo con el JSON solicitado.`;
+    async function geminiRequest(text) {
+        const body = { contents: [ { parts: [ { text: GEMINI_CONTEXT + "\n" + text } ] } ] };
+        const res = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${GEMINI_API_KEY}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body)
+        });
+        if (!res.ok) throw new Error('Gemini request failed');
+        const data = await res.json();
+        return (((data.candidates || [])[0] || {}).content || {}).parts[0]?.text || '';
+    }
+
+    async function checkGeminiAvailability() {
+        try {
+            await geminiRequest('Di \"ok\"');
+            aiAvailable = true;
+            if (aiStatusLabel) aiStatusLabel.textContent = 'IA: disponible';
+        } catch(e) {
+            aiAvailable = false;
+            if (aiStatusLabel) aiStatusLabel.textContent = 'IA: no disponible';
+        }
+    }
+
+    async function analyzeDuplicatesWithAI(list) {
+        if (!aiAvailable) return [];
+        const prompt = `Lista actual: ${JSON.stringify(currentBackupData.expenses.map(e => ({name: e.name, date: e.movement_date ? getISODateString(new Date(e.movement_date)) : (e.start_date ? getISODateString(new Date(e.start_date)) : ''), amount: parseFloat(e.amount)})))}. Nuevos gastos: ${JSON.stringify(list)}. Devuelve solo un array JSON de indices de nuevos gastos que ya existen.`;
+        const reply = await geminiRequest(prompt);
+        try { return JSON.parse(reply); } catch { return []; }
+    }
 
     // --- BLOQUEO DE EDICIÓN ---
     let editLockAcquired = false;
@@ -1875,12 +1919,22 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // --- IMPORTACIÓN MASIVA DE GASTOS ---
     function showImportExpensesModal() {
+        selectedExpenseFile = null;
+        if (expenseDropZone) expenseDropZone.textContent = "Arrastra el archivo .xlsx aquí o haz clic para seleccionar";
+        if (analyzeImportButton) { analyzeImportButton.disabled = true; analyzeImportButton.textContent = "Procesar archivo"; }
         if (importExpensesModal) importExpensesModal.style.display = 'flex';
+        aiDuplicateIndexes.clear();
+        if (aiStatusLabel) aiStatusLabel.textContent = 'IA: verificando...';
+        checkGeminiAvailability();
     }
     function closeImportExpensesModal() {
         if (importExpensesModal) importExpensesModal.style.display = 'none';
         parsedImportData = [];
         importHeaders = [];
+        aiDuplicateIndexes.clear();
+        selectedExpenseFile = null;
+        if (expenseDropZone) expenseDropZone.textContent = "Arrastra el archivo .xlsx aquí o haz clic para seleccionar";
+        if (analyzeImportButton) { analyzeImportButton.disabled = true; analyzeImportButton.textContent = "Procesar archivo"; }
         if (importTableContainer) importTableContainer.innerHTML = '';
         if (columnMappingDiv) columnMappingDiv.style.display = 'none';
         if (bankProfileSelect) bankProfileSelect.value = 'auto';
@@ -1941,6 +1995,7 @@ document.addEventListener('DOMContentLoaded', () => {
             mapDateSelect.value = importHeaders.find(h => /fecha/i.test(h)) || '';
             mapDescSelect.value = importHeaders.find(h => /desc/i.test(h)) || '';
             mapAmountSelect.value = importHeaders.find(h => /monto/i.test(h)) || '';
+            if (profileKey === 'auto') requestAIMapping();
         }
         renderImportTable();
     }
@@ -1957,8 +2012,9 @@ document.addEventListener('DOMContentLoaded', () => {
         columnMappingDiv.style.display = 'flex';
         const bankProfileDiv = document.getElementById('bank-profile');
         if (bankProfileDiv) bankProfileDiv.style.display = 'flex';
+        requestAIDuplicates();
     }
-    function renderImportTable() {
+function renderImportTable() {
         if (!importTableContainer) return;
         importTableContainer.innerHTML = '';
         const dateCol = mapDateSelect.value;
@@ -1976,7 +2032,9 @@ document.addEventListener('DOMContentLoaded', () => {
             const dateStr = dateObj ? getISODateString(dateObj) : '';
             const desc = row[descCol] !== undefined ? String(row[descCol]) : '';
             const amt = row[amountCol];
-            const isDup = checkExpenseDuplicate(desc, dateStr, parseFloat(amt));
+            const localDup = checkExpenseDuplicate(desc, dateStr, parseFloat(amt));
+            const aiDup = aiDuplicateIndexes.has(idx);
+            const isDup = localDup || aiDup;
             const tr = document.createElement('tr');
             if (isDup) tr.classList.add('duplicate-row');
             const chkCell = tr.insertCell();
@@ -1992,32 +2050,72 @@ document.addEventListener('DOMContentLoaded', () => {
         table.appendChild(tbody);
         importTableContainer.appendChild(table);
     }
-    function handleExpenseFile(file) {
-        const reader = new FileReader();
-        reader.onload = function(e) {
-            const data = new Uint8Array(e.target.result);
-            const wb = XLSX.read(data, { type: 'array' });
-            const sheet = wb.Sheets[wb.SheetNames[0]];
-            const json = XLSX.utils.sheet_to_json(sheet, { header: 1 });
-            if (!json.length) return;
-            importHeaders = json[0];
-            parsedImportData = json.slice(1).map(r => {
-                const obj = {};
-                importHeaders.forEach((h,i)=>{ obj[h] = r[i]; });
-                return obj;
-            });
-            let detected = 'auto';
-            for (const [key, prof] of Object.entries(bankProfiles)) {
-                if (prof.matchFileName && prof.matchFileName.test(file.name)) {
-                    detected = key; break;
-                }
-            }
-            if (bankProfileSelect) bankProfileSelect.value = detected;
-            renderMappingSelectors();
-        };
-        reader.readAsArrayBuffer(file);
+
+    async function requestAIMapping() {
+        if (!aiAvailable || !parsedImportData.length) return;
+        const sample = parsedImportData.slice(0, 3).map(row => {
+            const obj = {};
+            importHeaders.forEach(h => { obj[h] = row[h]; });
+            return obj;
+        });
+        const prompt = `Encabezados: ${JSON.stringify(importHeaders)}. Ejemplos: ${JSON.stringify(sample)}. Devuelve solo un JSON con las claves \"date\", \"description\" y \"amount\" indicando la columna correspondiente`;
+        try {
+            const reply = await geminiRequest(prompt);
+            const mapping = JSON.parse(reply);
+            if (mapping.date && importHeaders.includes(mapping.date)) mapDateSelect.value = mapping.date;
+            if (mapping.description && importHeaders.includes(mapping.description)) mapDescSelect.value = mapping.description;
+            if (mapping.amount && importHeaders.includes(mapping.amount)) mapAmountSelect.value = mapping.amount;
+        } catch(e) {
+            console.error('AI mapping error', e);
+        }
+        renderImportTable();
+        requestAIDuplicates();
     }
 
+    async function requestAIDuplicates() {
+        if (!aiAvailable) { renderImportTable(); return; }
+        const dateCol = mapDateSelect.value;
+        const descCol = mapDescSelect.value;
+        const amountCol = mapAmountSelect.value;
+        if (!dateCol || !descCol || !amountCol) { renderImportTable(); return; }
+        const list = parsedImportData.map((row, idx) => {
+            const dateObj = parseExcelDate(row[dateCol]);
+            const dateStr = dateObj ? getISODateString(dateObj) : '';
+            const desc = row[descCol] !== undefined ? String(row[descCol]) : '';
+            const amt = parseFloat(row[amountCol] || 0);
+            return { index: idx, name: desc, date: dateStr, amount: amt };
+        });
+        try {
+            const dups = await analyzeDuplicatesWithAI(list);
+            aiDuplicateIndexes = new Set(dups);
+        } catch(e) {
+            console.error(e);
+            aiDuplicateIndexes = new Set();
+        }
+        renderImportTable();
+    function handleExpenseFile(file) {
+        return new Promise(resolve => {
+            const reader = new FileReader();
+            reader.onload = async function(e) {
+                const data = new Uint8Array(e.target.result);
+                const wb = XLSX.read(data, { type: "array" });
+                const sheet = wb.Sheets[wb.SheetNames[0]];
+                const json = XLSX.utils.sheet_to_json(sheet, { header: 1 });
+                if (!json.length) { resolve(); return; }
+                importHeaders = json[0];
+                parsedImportData = json.slice(1).map(r => { const obj = {}; importHeaders.forEach((h,i)=>{ obj[h]=r[i]; }); return obj; });
+                let detected = "auto";
+                for (const [key, prof] of Object.entries(bankProfiles)) {
+                    if (prof.matchFileName && prof.matchFileName.test(file.name)) { detected = key; break; }
+                }
+                if (bankProfileSelect) bankProfileSelect.value = detected;
+                renderMappingSelectors();
+                await requestAIDuplicates();
+                resolve();
+            };
+            reader.readAsArrayBuffer(file);
+        });
+    }
     openImportExpensesButtons.forEach(btn => btn.addEventListener("click", showImportExpensesModal));
     if (importExpensesModalClose) importExpensesModalClose.addEventListener('click', closeImportExpensesModal);
     if (importExpensesModal) importExpensesModal.addEventListener('click', (e)=>{ if(e.target===importExpensesModal) closeImportExpensesModal(); });
@@ -2025,13 +2123,14 @@ document.addEventListener('DOMContentLoaded', () => {
         expenseDropZone.addEventListener('click', () => { if(expenseFileInput) expenseFileInput.click(); });
         expenseDropZone.addEventListener('dragover', e => { e.preventDefault(); expenseDropZone.classList.add('dragover'); });
         expenseDropZone.addEventListener('dragleave', () => expenseDropZone.classList.remove('dragover'));
-        expenseDropZone.addEventListener('drop', e => { e.preventDefault(); expenseDropZone.classList.remove('dragover'); if (e.dataTransfer.files[0]) handleExpenseFile(e.dataTransfer.files[0]); });
+        expenseDropZone.addEventListener('drop', e => { e.preventDefault(); expenseDropZone.classList.remove('dragover'); if (e.dataTransfer.files[0]) { selectedExpenseFile = e.dataTransfer.files[0]; expenseDropZone.textContent = 'Archivo: ' + selectedExpenseFile.name; if (analyzeImportButton) analyzeImportButton.disabled = false; } });
     }
-    if (expenseFileInput) expenseFileInput.addEventListener('change', e => { if (e.target.files[0]) handleExpenseFile(e.target.files[0]); });
-    if (mapDateSelect) mapDateSelect.addEventListener('change', renderImportTable);
-    if (mapDescSelect) mapDescSelect.addEventListener('change', renderImportTable);
-    if (mapAmountSelect) mapAmountSelect.addEventListener('change', renderImportTable);
-    if (bankProfileSelect) bankProfileSelect.addEventListener('change', () => applyBankProfile(bankProfileSelect.value));
+    if (expenseFileInput) expenseFileInput.addEventListener('change', e => { if (e.target.files[0]) { selectedExpenseFile = e.target.files[0]; expenseDropZone.textContent = 'Archivo: ' + selectedExpenseFile.name; if (analyzeImportButton) analyzeImportButton.disabled = false; } });
+    if (mapDateSelect) mapDateSelect.addEventListener('change', requestAIDuplicates);
+    if (analyzeImportButton) analyzeImportButton.addEventListener("click", () => { if (!selectedExpenseFile) return; analyzeImportButton.disabled = true; analyzeImportButton.textContent = "Procesando..."; handleExpenseFile(selectedExpenseFile).then(() => { analyzeImportButton.textContent = "Procesar archivo"; analyzeImportButton.disabled = false; }); });
+    if (mapDescSelect) mapDescSelect.addEventListener('change', requestAIDuplicates);
+    if (mapAmountSelect) mapAmountSelect.addEventListener('change', requestAIDuplicates);
+    if (bankProfileSelect) bankProfileSelect.addEventListener('change', () => { applyBankProfile(bankProfileSelect.value); requestAIDuplicates(); });
     if (mergeExpensesButton) mergeExpensesButton.addEventListener('click', () => {
         const dateCol = mapDateSelect.value;
         const descCol = mapDescSelect.value;
@@ -2056,6 +2155,28 @@ document.addEventListener('DOMContentLoaded', () => {
         renderCashflowTable();
         closeImportExpensesModal();
     });
+
+    async function sendAIChat() {
+        const text = aiChatInput.value.trim();
+        if (!text) return;
+        const msgDiv = document.createElement('div');
+        msgDiv.textContent = 'Tú: ' + text;
+        aiChatMessages.appendChild(msgDiv);
+        aiChatInput.value = '';
+        try {
+            const reply = await geminiRequest(text);
+            const rDiv = document.createElement('div');
+            rDiv.textContent = 'IA: ' + reply;
+            aiChatMessages.appendChild(rDiv);
+            aiChatMessages.scrollTop = aiChatMessages.scrollHeight;
+        } catch(e) {
+            const errDiv = document.createElement('div');
+            errDiv.textContent = 'IA sin respuesta';
+            aiChatMessages.appendChild(errDiv);
+        }
+    }
+    if (aiChatSend) aiChatSend.addEventListener('click', sendAIChat);
+    if (aiChatInput) aiChatInput.addEventListener('keydown', e => { if (e.key === 'Enter') { e.preventDefault(); sendAIChat(); } });
 
     // --- LÓGICA PESTAÑA PRESUPUESTOS ---
     function resetBudgetForm() {

--- a/config.js
+++ b/config.js
@@ -30,6 +30,9 @@ firebase.initializeApp(firebaseConfig);
 const auth = firebase.auth();
 const database = firebase.database();
 
+// Clave para acceder a la API de Gemini
+const GEMINI_API_KEY = "AIzaSyB_IazCUbRrYp96Em5s3z5MXXfBEbCC86o";
+
 // --- Funciones de utilidad ---
 
 /**

--- a/index.html
+++ b/index.html
@@ -494,8 +494,10 @@
                 <div class="modal-content">
                     <span id="import-expenses-modal-close" class="modal-close">&times;</span>
                     <h3>Importar Gastos desde Excel</h3>
+                    <p id="ai-status">IA: verificando...</p>
                     <div id="expense-drop-zone">Arrastra el archivo .xlsx aquí o haz clic para seleccionar</div>
                     <input type="file" id="expense-file-input" accept=".xlsx,.xls" style="display:none;">
+                    <button type="button" id="analyze-import-button" disabled>Procesar archivo</button>
                     <div id="bank-profile" style="display:none;">
                         <label>Perfil<select id="import-bank-profile">
                             <option value="auto">Automático</option>
@@ -509,6 +511,13 @@
                     </div>
                     <div id="import-table-container"></div>
                     <button type="button" id="merge-expenses-button" class="accent">Unir</button>
+                    <div id="ai-chat-container">
+                        <div id="ai-chat-messages" class="chat-messages"></div>
+                        <div class="chat-input-group">
+                            <input type="text" id="ai-chat-input" placeholder="Pregunta a la IA">
+                            <button type="button" id="ai-chat-send">Enviar</button>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/style.css
+++ b/style.css
@@ -1323,3 +1323,27 @@ td.reimbursement-income {
 }
 .breakdown-popup li { margin: 2px 0; }
 
+#ai-chat-container {
+    border-top: 1px solid var(--border-color);
+    margin-top: 10px;
+    padding-top: 10px;
+}
+
+.chat-messages {
+    height: 120px;
+    overflow-y: auto;
+    border: 1px solid var(--border-color);
+    padding: 5px;
+    margin-bottom: 5px;
+    background-color: var(--input-bg);
+}
+
+.chat-input-group {
+    display: flex;
+    gap: 5px;
+}
+
+.chat-input-group input {
+    flex: 1;
+}
+


### PR DESCRIPTION
## Summary
- add manual processing button before analyzing expense files
- enhance base Gemini prompt with duplicate and installment instructions
- show & reset processing UI state when opening/closing the import modal
- only parse expense file after clicking the new button

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_686700dcac3083208a82c5e9eb11383a