### PR TITLE
Add CSS theme variations

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,12 @@ La aplicación utiliza Firebase Realtime Database para almacenar todos los datos
 
 *   **Tasa de Cambio USD/CLP:** La aplicación obtiene la tasa de cambio entre USD y CLP de forma automática desde la API de CoinGecko. Esta tasa se muestra en la pestaña de "Ajustes" y es solo para fines informativos, no se almacena persistente con los datos del usuario en Firebase.
 *   **Validación de Nombres/Claves:** Para asegurar la compatibilidad con Firebase Realtime Database, los nombres de ingresos, gastos y categorías no deben contener caracteres prohibidos por Firebase para las claves (ej: `.`, `$`, `#`, `[`, `]`, `/`). La aplicación incluye validaciones para prevenir el guardado de datos con estos caracteres en nombres que podrían ser usados como claves.
+## Temas de Diseño
+
+Se incluyen cuatro archivos CSS con variaciones de diseño para la aplicación. El comportamiento y el HTML se mantienen intactos; únicamente cambian los estilos visuales. Para probar un tema diferente, sustituye la referencia a `style.css` en `index.html` por el archivo correspondiente.
+
+- `style.css`: tema por defecto.
+- `style-dark.css`: paleta oscura con tonos azules.
+- `style-ocean.css`: apariencia inspirada en el mar.
+- `style-retro.css`: estilo retro con colores cálidos y tipografía monoespaciada.
+

--- a/style-dark.css
+++ b/style-dark.css
@@ -1,0 +1,27 @@
+@import url("style.css");
+
+/* Dark theme overrides */
+:root {
+  --primary-color: #74b9ff;
+  --primary-hover: #4a99e2;
+  --accent-color: #fab1a0;
+  --accent-hover: #e17055;
+  --danger-color: #e74c3c;
+  --danger-hover: #c0392b;
+  --text-color: #dfe6e9;
+  --light-text: #b2bec3;
+  --background: #2d3436;
+  --card-bg: #3d3d3d;
+  --border-color: #555;
+  --header-bg: #444;
+  --shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+  --alt-row-bg: #2f3640;
+  --row-hover-bg: #353b48;
+  --body-header-row-bg: #2d3436;
+  --disabled-bg: #555;
+}
+
+body {
+  background: var(--background);
+  color: var(--text-color);
+}

--- a/style-ocean.css
+++ b/style-ocean.css
@@ -1,0 +1,28 @@
+@import url("style.css");
+
+/* Ocean theme overrides */
+:root {
+  --primary-color: #008080;
+  --primary-hover: #006666;
+  --accent-color: #00cec9;
+  --accent-hover: #00b3b1;
+  --danger-color: #d63031;
+  --danger-hover: #b52a2a;
+  --text-color: #032d3c;
+  --light-text: #0984e3;
+  --background: #e0f7fa;
+  --card-bg: #ffffff;
+  --border-color: #b2ebf2;
+  --header-bg: #b2f0ff;
+  --shadow: 0 4px 12px rgba(0, 128, 128, 0.2);
+  --alt-row-bg: #d0f0f0;
+  --row-hover-bg: #b2e4e4;
+  --body-header-row-bg: #c8f3f9;
+  --disabled-bg: #e0e0e0;
+}
+
+body {
+  background: linear-gradient(135deg, var(--background) 0%, #d0f4f9 100%);
+  color: var(--text-color);
+  font-family: 'Arial', sans-serif;
+}

--- a/style-retro.css
+++ b/style-retro.css
@@ -1,0 +1,31 @@
+@import url("style.css");
+
+/* Retro theme overrides */
+:root {
+  --primary-color: #ff6b6b;
+  --primary-hover: #ee5253;
+  --accent-color: #feca57;
+  --accent-hover: #ffa801;
+  --danger-color: #ff9f43;
+  --danger-hover: #e58e26;
+  --text-color: #2d3436;
+  --light-text: #636e72;
+  --background: #fff9e6;
+  --card-bg: #fffffc;
+  --border-color: #ffd79a;
+  --header-bg: #ffeaa7;
+  --shadow: 0 4px 12px rgba(255, 107, 107, 0.25);
+  --alt-row-bg: #fff5d9;
+  --row-hover-bg: #ffeda6;
+  --body-header-row-bg: #fffbef;
+  --disabled-bg: #f0e5cf;
+}
+
+body {
+  font-family: 'Courier New', Courier, monospace;
+  background: linear-gradient(135deg, var(--background) 0%, #ffeaa7 100%);
+}
+
+h1, h2, h3, h4 {
+  font-family: 'Lucida Console', Monaco, monospace;
+}


### PR DESCRIPTION
## Summary
- add 3 alternative style sheets: dark, ocean, and retro themes
- document available themes in README

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_68695475e11c83208bed52f736ca707e