### PR TITLE
Apply Apple-inspired design palette

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,23 +1,24 @@
 /* Variables globales */
 :root {
-  --primary-color: #3867d6;
-  --primary-hover: #2d56bf;
-  --accent-color: #20bf6b;
-  --accent-hover: #1aa059;
-  --danger-color: #eb3b5a;
-  --danger-hover: #d63151;
-  --text-color: #2d3436;
-  --light-text: #636e72;
-  --background: #f7f9fc;
+  /* Apple inspired palette */
+  --primary-color: #0071e3;
+  --primary-hover: #005bb5;
+  --accent-color: #34c759;
+  --accent-hover: #28a745;
+  --danger-color: #ff3b30;
+  --danger-hover: #e02e24;
+  --text-color: #1c1c1e;
+  --light-text: #6e6e73;
+  --background: #f5f5f7;
   --card-bg: #ffffff;
-  --border-color: #dfe6e9;
-  --header-bg: #f1f6fb;
-  --shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  --border-color: #d1d1d6;
+  --header-bg: #f9f9fa;
+  --shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
   --transition: all 0.3s ease;
-  --radius: 8px;
-  --alt-row-bg: #f8f9fa;
-  --row-hover-bg: #e9ecef;
-  --body-header-row-bg: #eef3f8;
+  --radius: 12px;
+  --alt-row-bg: #f2f2f7;
+  --row-hover-bg: #e5e5ea;
+  --body-header-row-bg: #eef1f5;
   --text-green: #20bf6b;
   --text-red: #eb3b5a;
   --text-orange: #fa8231;
@@ -32,10 +33,10 @@
 }
 
 body {
-  font-family: 'Segoe UI', -apple-system, BlinkMacSystemFont, Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  font-family: 'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
   margin: 0;
   padding: 10px;
-  background: linear-gradient(135deg, var(--background) 0%, #e0e7ff 100%);
+  background-color: var(--background);
   color: var(--text-color);
   line-height: 1.6;
 }


### PR DESCRIPTION
## Summary
- refresh global color variables with Apple-inspired hues
- update body font and background for minimal look

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_686957d776ec83209a74b809dfb75190