### PR TITLE
Apply Apple-inspired visual style

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,27 +1,27 @@
 /* Variables globales */
 :root {
-  --primary-color: #3867d6;
-  --primary-hover: #2d56bf;
-  --accent-color: #20bf6b;
-  --accent-hover: #1aa059;
-  --danger-color: #eb3b5a;
-  --danger-hover: #d63151;
-  --text-color: #2d3436;
-  --light-text: #636e72;
-  --background: #f7f9fc;
+  --primary-color: #007aff;
+  --primary-hover: #0060df;
+  --accent-color: #34c759;
+  --accent-hover: #28a745;
+  --danger-color: #ff3b30;
+  --danger-hover: #e0463f;
+  --text-color: #1d1d1f;
+  --light-text: #6e6e73;
+  --background: #f5f5f7;
   --card-bg: #ffffff;
-  --border-color: #dfe6e9;
-  --header-bg: #f1f6fb;
-  --shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  --border-color: #d1d1d6;
+  --header-bg: #f5f5f7;
+  --shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
   --transition: all 0.3s ease;
-  --radius: 8px;
-  --alt-row-bg: #f8f9fa;
-  --row-hover-bg: #e9ecef;
-  --body-header-row-bg: #eef3f8;
-  --text-green: #20bf6b;
-  --text-red: #eb3b5a;
-  --text-orange: #fa8231;
-  --disabled-bg: #f0f0f0;
+  --radius: 12px;
+  --alt-row-bg: #f8f8fa;
+  --row-hover-bg: #f0f0f3;
+  --body-header-row-bg: #f5f5f7;
+  --text-green: #34c759;
+  --text-red: #ff3b30;
+  --text-orange: #ff9500;
+  --disabled-bg: #f2f2f7;
 }
 
 /* Reseteo y estilos base */
@@ -32,10 +32,10 @@
 }
 
 body {
-  font-family: 'Segoe UI', -apple-system, BlinkMacSystemFont, Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
   margin: 0;
   padding: 10px;
-  background: linear-gradient(135deg, var(--background) 0%, #e0e7ff 100%);
+  background: var(--background);
   color: var(--text-color);
   line-height: 1.6;
 }


### PR DESCRIPTION
## Summary
- adopt a lighter color palette and fonts closer to Apple's design
- remove gradient background for a cleaner look

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_686957d776ec83209a74b809dfb75190