### PR TITLE
Update styles to mimic Apple aesthetic

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,26 +1,26 @@
 /* Variables globales */
 :root {
-  --primary-color: #3867d6;
-  --primary-hover: #2d56bf;
-  --accent-color: #20bf6b;
-  --accent-hover: #1aa059;
-  --danger-color: #eb3b5a;
-  --danger-hover: #d63151;
-  --text-color: #2d3436;
-  --light-text: #636e72;
-  --background: #f7f9fc;
+  --primary-color: #007aff;
+  --primary-hover: #0060d5;
+  --accent-color: #34c759;
+  --accent-hover: #28a745;
+  --danger-color: #ff3b30;
+  --danger-hover: #e33228;
+  --text-color: #1c1c1e;
+  --light-text: #6e6e73;
+  --background: #f5f5f7;
   --card-bg: #ffffff;
-  --border-color: #dfe6e9;
-  --header-bg: #f1f6fb;
-  --shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  --border-color: #d2d2d7;
+  --header-bg: #f0f0f5;
+  --shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
   --transition: all 0.3s ease;
-  --radius: 8px;
-  --alt-row-bg: #f8f9fa;
-  --row-hover-bg: #e9ecef;
-  --body-header-row-bg: #eef3f8;
-  --text-green: #20bf6b;
-  --text-red: #eb3b5a;
-  --text-orange: #fa8231;
+  --radius: 12px;
+  --alt-row-bg: #f9f9fa;
+  --row-hover-bg: #e9e9ec;
+  --body-header-row-bg: #f1f1f4;
+  --text-green: #34c759;
+  --text-red: #ff3b30;
+  --text-orange: #ff9500;
   --disabled-bg: #f0f0f0;
 }
 
@@ -32,19 +32,19 @@
 }
 
 body {
-  font-family: 'Segoe UI', -apple-system, BlinkMacSystemFont, Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
   margin: 0;
   padding: 10px;
-  background: linear-gradient(135deg, var(--background) 0%, #e0e7ff 100%);
+  background: var(--background);
   color: var(--text-color);
   line-height: 1.6;
 }
 
 .container {
   max-width: 1300px;
-  margin: 10px auto;
+  margin: 20px auto;
   background-color: var(--card-bg);
-  padding: 15px;
+  padding: 20px;
   border-radius: var(--radius);
   box-shadow: var(--shadow);
 }
@@ -79,7 +79,7 @@ h1::after {
 h2 {
   font-size: 1.4rem;
   margin-top: 1.2rem;
-  border-left: 4px solid var(--primary-color);
+  border-left: 3px solid var(--primary-color);
   padding-left: 10px;
 }
 h3 {
@@ -137,7 +137,7 @@ input[type="date"]:focus,
 select:focus {
   outline: none;
   border-color: var(--primary-color);
-  box-shadow: 0 0 0 2px rgba(56, 103, 214, 0.15);
+  box-shadow: 0 0 0 2px rgba(0, 122, 255, 0.15);
 }
 
 label {
@@ -516,8 +516,8 @@ td.reimbursement-income {
 #cashflow-semanal-table td.current-period {
   background-image: repeating-linear-gradient(
     45deg,
-    rgba(56, 103, 214, 0.10) 0,
-    rgba(56, 103, 214, 0.10) 2px,
+    rgba(0, 122, 255, 0.10) 0,
+    rgba(0, 122, 255, 0.10) 2px,
     transparent 2px,
     transparent 4px
   );
@@ -530,7 +530,7 @@ td.reimbursement-income {
   font-style: italic;
   margin: 15px 0;
   color: var(--light-text);
-  background-color: rgba(56, 103, 214, 0.05);
+  background-color: rgba(0, 122, 255, 0.05);
   padding: 8px;
   border-radius: var(--radius);
   animation: pulse 1.5s infinite;


### PR DESCRIPTION
## Summary
- adopt a lighter Apple-inspired color palette
- tweak fonts and spacing for a more minimalist feel
- update highlights and focus styles to new colors

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_686957d776ec83209a74b809dfb75190