### PR TITLE
Update color palette for cleaner UI

### DIFF
--- a/app.js
+++ b/app.js
@@ -3783,7 +3783,7 @@ function getMondayOfWeek(year, week) {
 
             const colorMap = {
                 'text-red': '#eb3b5a',
-                'text-blue': '#3867d6',
+                'text-blue': '#0694F6',
                 'text-green': '#20bf6b',
                 'text-orange': '#fa8231'
             };
@@ -3793,22 +3793,22 @@ function getMondayOfWeek(year, week) {
                 body: pageRows,
                 startY,
                 theme: 'grid',
-                styles: { fontSize: 6, textColor: '#2d3436' },
-                headStyles: { fillColor: '#f1f6fb', textColor: '#3867d6', fontStyle: 'bold' },
-                alternateRowStyles: { fillColor: '#f8f9fa' },
+                styles: { fontSize: 6, textColor: '#041830' },
+                headStyles: { fillColor: '#82DAFE', textColor: '#056DA4', fontStyle: 'bold' },
+                alternateRowStyles: { fillColor: '#2AC3FD' },
                 margin,
                 didParseCell: function (data) {
                     if (data.section === 'body') {
                         const rowCls = rowClasses[data.row.index] || '';
                         const cellCls = pageCellClasses[data.row.index][data.column.index] || '';
-                        if (rowCls.includes('bg-header')) data.cell.styles.fillColor = '#eef3f8';
+                        if (rowCls.includes('bg-header')) data.cell.styles.fillColor = '#82DAFE';
                         if (cellCls.includes('bold')) data.cell.styles.fontStyle = 'bold';
                         for (const cls in colorMap) {
                             if (cellCls.includes(cls)) { data.cell.styles.textColor = colorMap[cls]; break; }
                         }
                     } else if (data.section === 'head') {
                         const cls = pageHeaderClasses[data.column.index] || '';
-                        if (cls.includes('current-period')) data.cell.styles.fillColor = '#eef3f8';
+                        if (cls.includes('current-period')) data.cell.styles.fillColor = '#82DAFE';
                     }
                 },
                 willDrawCell: function (data) {
@@ -3819,7 +3819,7 @@ function getMondayOfWeek(year, week) {
                         // Disable default fill so our background isn't overwritten
                         data.cell.styles.fillColor = null;
                         const { x, y, width, height } = data.cell;
-                        doc.setFillColor(238, 243, 248); // #eef3f8
+                        doc.setFillColor(130, 218, 254); // #82DAFE
                         doc.rect(x, y, width, height, 'F');
                         const spacing = 6;
                         doc.setLineWidth(0.4);
@@ -3875,9 +3875,9 @@ function getMondayOfWeek(year, week) {
                 body: rows,
                 startY: margin.top,
                 theme: 'grid',
-                styles: { fontSize: 7, textColor: '#2d3436' },
-                headStyles: { fillColor: '#f1f6fb', textColor: '#3867d6', fontStyle: 'bold' },
-                alternateRowStyles: { fillColor: '#f8f9fa' },
+                styles: { fontSize: 7, textColor: '#041830' },
+                headStyles: { fillColor: '#82DAFE', textColor: '#056DA4', fontStyle: 'bold' },
+                alternateRowStyles: { fillColor: '#2AC3FD' },
                 margin
             });
         }

--- a/style.css
+++ b/style.css
@@ -1,23 +1,23 @@
 /* Variables globales */
 :root {
-  --primary-color: #007aff;
-  --primary-hover: #0060d5;
-  --accent-color: #34c759;
-  --accent-hover: #28a745;
+  --primary-color: #056DA4;
+  --primary-hover: #00557A;
+  --accent-color: #0694F6;
+  --accent-hover: #0579D0;
   --danger-color: #ff3b30;
   --danger-hover: #e33228;
-  --text-color: #1c1c1e;
-  --light-text: #6e6e73;
+  --text-color: #041830;
+  --light-text: #317EC4;
   --background: #f5f5f7;
   --card-bg: #ffffff;
-  --border-color: #d2d2d7;
-  --header-bg: #f0f0f5;
+  --border-color: #659CD2;
+  --header-bg: #82DAFE;
   --shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
   --transition: all 0.3s ease;
   --radius: 12px;
-  --alt-row-bg: #f9f9fa;
-  --row-hover-bg: #e9e9ec;
-  --body-header-row-bg: #f1f1f4;
+  --alt-row-bg: #82DAFE;
+  --row-hover-bg: #2AC3FD;
+  --body-header-row-bg: #5D84F9;
   --text-green: #34c759;
   --text-red: #ff3b30;
   --text-orange: #ff9500;
@@ -639,7 +639,7 @@ td.reimbursement-income {
     margin-top: 15px; /* Más espacio arriba */
     margin-bottom: 10px;
     padding: 8px;
-    background-color: #f0f4f8; /* Un fondo sutil */
+    background-color: #82DAFE; /* Un fondo sutil */
     border-left: 3px solid var(--primary-color);
     font-size: 0.9em;
     border-radius: 4px;
@@ -951,7 +951,7 @@ td.reimbursement-income {
     font-weight: 600; 
     color: var(--primary-color);
     padding: 2px 6px; 
-    background-color: #eef3f8; 
+    background-color: #82DAFE;
     border-radius: 4px; 
     white-space: nowrap;
 }


### PR DESCRIPTION
## Summary
- refresh UI colors with new blue palette
- adjust table export colors for PDFs

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_686c4ff1c96483209471407c5b0b40c4