### PR TITLE
Default to Log tab

### DIFF
--- a/app.js
+++ b/app.js
@@ -412,7 +412,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function showMainContentScreen() {
         mainContentContainer.style.display = 'block';
-        activateTab('gastos'); // Activate a default tab
+        activateTab('log'); // Activate Log tab by default
         fetchAndUpdateUSDCLPRate(); // Fetch USD/CLP rate when main content is shown
         if (typeof updatePieMonthChart === 'function') updatePieMonthChart();
         if (typeof updatePieWeekChart === 'function') updatePieWeekChart();


### PR DESCRIPTION
## Summary
- open the Log tab by default when showing the main content screen

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_687a5bf057ec83208636adc82e7a249b