### PR TITLE
Add month selector for budget summary

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,6 +292,12 @@
                             </table>
                         </div>
                          <h3>Resumen Gasto vs Presupuesto (Mes Actual/Seleccionado)</h3>
+                        <div class="budget-period-selector">
+                            <button id="prev-budget-month-button" title="Mes Anterior">&lt;</button>
+                            <select id="budget-year-select"></select>
+                            <select id="budget-month-select"></select>
+                            <button id="next-budget-month-button" title="Mes Siguiente">&gt;</button>
+                        </div>
                         <div class="table-responsive dynamic-table-scroll" id="budget-summary-table-container">
                             <table id="budget-summary-table">
                                 <thead>

--- a/style.css
+++ b/style.css
@@ -674,6 +674,19 @@ td.reimbursement-income {
     margin-bottom: 0;
 }
 
+/* Estilos para Pestaña Presupuestos */
+.budget-period-selector {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    margin-bottom: 15px;
+}
+.budget-period-selector select, .budget-period-selector button {
+    padding: 8px 10px;
+    margin-bottom: 0;
+}
+
 /* Selector de período para gráficos adicionales */
 .chart-period-selector {
     display: flex;


### PR DESCRIPTION
## Summary
- allow browsing budget summary by month with new selectors and navigation buttons
- style new budget period selector
- render summary for the selected month and initialize selectors when data loads

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_687a634585e48320a2d1e6f5e5ee2c36