### PR TITLE
Enable monthly budget summary navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -291,7 +291,13 @@
                                     </tbody>
                             </table>
                         </div>
-                         <h3>Resumen Gasto vs Presupuesto (Mes Actual/Seleccionado)</h3>
+                        <h3 id="budget-summary-title">Resumen Gasto vs Presupuesto (Mes Actual/Seleccionado)</h3>
+                        <div class="budget-period-selector">
+                            <button id="budget-prev-month-button" title="Mes Anterior">&lt;</button>
+                            <select id="budget-year-select"></select>
+                            <select id="budget-month-select"></select>
+                            <button id="budget-next-month-button" title="Mes Siguiente">&gt;</button>
+                        </div>
                         <div class="table-responsive dynamic-table-scroll" id="budget-summary-table-container">
                             <table id="budget-summary-table">
                                 <thead>

--- a/style.css
+++ b/style.css
@@ -674,6 +674,19 @@ td.reimbursement-income {
     margin-bottom: 0;
 }
 
+/* Estilos para Pestaña Presupuestos */
+.budget-period-selector {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    margin-bottom: 15px;
+}
+.budget-period-selector select, .budget-period-selector button {
+    padding: 8px 10px;
+    margin-bottom: 0;
+}
+
 /* Selector de período para gráficos adicionales */
 .chart-period-selector {
     display: flex;


### PR DESCRIPTION
## Summary
- allow choosing month/year for budget summary
- add navigation buttons to budget tab
- sync selectors after settings or data load
- style monthly selector

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_687a634585e48320a2d1e6f5e5ee2c36