### PR TITLE
Add month selector to budget summary

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,6 +292,12 @@
                             </table>
                         </div>
                          <h3>Resumen Gasto vs Presupuesto (Mes Actual/Seleccionado)</h3>
+                        <div class="budget-period-selector">
+                            <button id="budget-prev-period-button" title="Mes Anterior">&lt;</button>
+                            <select id="budget-year-select"></select>
+                            <select id="budget-month-select"></select>
+                            <button id="budget-next-period-button" title="Mes Siguiente">&gt;</button>
+                        </div>
                         <div class="table-responsive dynamic-table-scroll" id="budget-summary-table-container">
                             <table id="budget-summary-table">
                                 <thead>

--- a/style.css
+++ b/style.css
@@ -674,6 +674,19 @@ td.reimbursement-income {
     margin-bottom: 0;
 }
 
+/* Estilos para Selección de Mes en Presupuestos */
+.budget-period-selector {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    margin: 10px 0;
+}
+.budget-period-selector select, .budget-period-selector button {
+    padding: 8px 10px;
+    margin-bottom: 0;
+}
+
 /* Selector de período para gráficos adicionales */
 .chart-period-selector {
     display: flex;
@@ -1100,6 +1113,17 @@ td.reimbursement-income {
       margin-bottom: 8px;
   }
   .payments-period-selector button {
+      flex-basis: auto;
+  }
+  .budget-period-selector {
+      flex-wrap: wrap;
+      justify-content: space-around;
+  }
+  .budget-period-selector select, .budget-period-selector button {
+      flex-basis: 45%;
+      margin-bottom: 8px;
+  }
+  .budget-period-selector button {
       flex-basis: auto;
   }
   .reminders-columns {


### PR DESCRIPTION
## Summary
- add year/month selectors for Budget tab
- mirror period controls to view budgets by month
- pull monthly expenses from cashflow calculation instead of recalculating

## Testing
- `node test_app_logic.js`

------
https://chatgpt.com/codex/tasks/task_e_687a634585e48320a2d1e6f5e5ee2c36