### PR TITLE
Fix budget summary to use monthly cash flow

### DIFF
--- a/app.js
+++ b/app.js
@@ -134,6 +134,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const saveBudgetButton = document.getElementById('save-budget-button');
     const budgetsTableView = document.querySelector('#budgets-table-view tbody');
     const budgetSummaryTableBody = document.querySelector('#budget-summary-table tbody');
+    const budgetPrevPeriodButton = document.getElementById('budget-prev-period-button');
+    const budgetNextPeriodButton = document.getElementById('budget-next-period-button');
+    const budgetYearSelect = document.getElementById('budget-year-select');
+    const budgetMonthSelect = document.getElementById('budget-month-select');
+    let currentBudgetViewDate = new Date();
 
     // --- ELEMENTOS PESTAÑA REGISTRO PAGOS ---
     const paymentsTabTitle = document.getElementById('payments-tab-title');
@@ -663,6 +668,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     renderLogTab();
                     activePaymentsPeriodicity = currentBackupData.analysis_periodicity || 'Mensual';
                     setupPaymentPeriodSelectors();
+                    setupBudgetPeriodSelectors();
                     setPaymentPeriodicity(activePaymentsPeriodicity);
                     renderCashflowTable();
 
@@ -707,6 +713,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     renderLogTab();
                     activePaymentsPeriodicity = currentBackupData.analysis_periodicity || 'Mensual';
                     setupPaymentPeriodSelectors();
+                    setupBudgetPeriodSelectors();
                     setPaymentPeriodicity(activePaymentsPeriodicity);
                     renderCashflowTable();
 
@@ -1144,7 +1151,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (tabId === 'grafico') {
             setPeriodicity(activeCashflowPeriodicity, 'chart');
         }
-        if (tabId === 'presupuestos') { renderBudgetsTable(); renderBudgetSummaryTable(); }
+        if (tabId === 'presupuestos') { setupBudgetPeriodSelectors(); renderBudgetsTable(); renderBudgetSummaryTableForSelectedPeriod(); }
         if (tabId === 'registro-pagos') { setupPaymentPeriodSelectors(); setPaymentPeriodicity(activePaymentsPeriodicity); }
         if (tabId === 'ajustes') {
             populateSettingsForm();
@@ -1383,10 +1390,11 @@ document.addEventListener('DOMContentLoaded', () => {
         renderCashflowTable();
         updateAnalysisModeLabels();
         setupPaymentPeriodSelectors();
+        setupBudgetPeriodSelectors();
         setPaymentPeriodicity(activePaymentsPeriodicity);
         renderBudgetsTable();
 
-        renderBudgetSummaryTable();
+        renderBudgetSummaryTableForSelectedPeriod();
     });
 
     if (printSummaryButton) {
@@ -2072,7 +2080,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!isFirebaseKeySafe(category)) { alert(`Categoría "${category}" con nombre no permitido.`); return; }
         if (!currentBackupData.budgets) currentBackupData.budgets = {};
         currentBackupData.budgets[category] = amount;
-        renderBudgetsTable(); renderBudgetSummaryTable(); renderCashflowTable();
+        renderBudgetsTable(); renderBudgetSummaryTableForSelectedPeriod(); renderCashflowTable();
         alert(`Presupuesto para "${category}" guardado como ${formatCurrencyJS(amount, currentBackupData.display_currency_symbol || '$')}.`);
     });
     budgetCategorySelect.addEventListener('change', () => {
@@ -2096,66 +2104,33 @@ document.addEventListener('DOMContentLoaded', () => {
     function renderBudgetSummaryTable() {
         if (!budgetSummaryTableBody || !currentBackupData) return;
         budgetSummaryTableBody.innerHTML = '';
-        if (!currentBackupData.analysis_start_date || !currentBackupData.expenses || !currentBackupData.budgets || !currentBackupData.expense_categories) {
+        if (!currentBackupData.analysis_start_date || !currentBackupData.expense_categories) {
             const row = budgetSummaryTableBody.insertRow();
             const cell = row.insertCell(); cell.colSpan = 5; cell.textContent = "Datos insuficientes."; cell.style.textAlign = "center";
             return;
         }
-        const analysisStartDate = new Date(currentBackupData.analysis_start_date);
-        const currentMonth = analysisStartDate.getUTCMonth();
-        const currentYear = analysisStartDate.getUTCFullYear();
-        const expensesThisMonth = {};
-        (currentBackupData.expenses || []).forEach(exp => {
-            if (!exp.start_date) return;
-            const expStartDate = new Date(exp.start_date);
-            let amountForSummary = 0;
-            if (exp.frequency === "Único") { if (expStartDate.getUTCFullYear() === currentYear && expStartDate.getUTCMonth() === currentMonth) amountForSummary = exp.amount; }
-            else if (exp.frequency === "Mensual") { if (expStartDate <= new Date(Date.UTC(currentYear, currentMonth + 1, 0)) && (!exp.end_date || new Date(exp.end_date) >= new Date(Date.UTC(currentYear, currentMonth, 1)))) amountForSummary = exp.amount; }
-            else if (exp.frequency === "Semanal") { if (expStartDate <= new Date(Date.UTC(currentYear, currentMonth + 1, 0)) && (!exp.end_date || new Date(exp.end_date) >= new Date(Date.UTC(currentYear, currentMonth, 1)))) amountForSummary = exp.amount * (52 / 12); } 
-            else if (exp.frequency === "Bi-semanal") { 
-                let paydays_in_month = 0;
-                let current_pay_date = new Date(expStartDate.getTime());
-                const month_start_date = new Date(Date.UTC(currentYear, currentMonth, 1));
-                const month_end_date = new Date(Date.UTC(currentYear, currentMonth + 1, 0));
-                while (current_pay_date <= month_end_date && (!exp.end_date || current_pay_date <= new Date(exp.end_date))) {
-                    if (current_pay_date >= month_start_date) {
-                        paydays_in_month++;
-                    }
-                    current_pay_date = addWeeks(current_pay_date, 2);
-                }
-                amountForSummary = exp.amount * paydays_in_month;
-            }
-            if (amountForSummary > 0) expensesThisMonth[exp.category] = (expensesThisMonth[exp.category] || 0) + amountForSummary;
-        });
 
-        (currentBackupData.incomes || []).forEach(reimbInc => {
-            if (!reimbInc.is_reimbursement || !reimbInc.reimbursement_category || !reimbInc.start_date) return;
-            const reimbStartDate = new Date(reimbInc.start_date);
-            if (reimbStartDate.getUTCFullYear() === currentYear && reimbStartDate.getUTCMonth() === currentMonth) {
-                let amountToReimburse = reimbInc.net_monthly;
-                if (reimbInc.frequency === "Semanal") amountToReimburse = reimbInc.net_monthly * (52 / 12);
-                else if (reimbInc.frequency === "Bi-semanal") {
-                    let paydays_in_month = 0;
-                    let current_pay_date = new Date(reimbStartDate.getTime());
-                    const month_start_date = new Date(Date.UTC(currentYear, currentMonth, 1));
-                    const month_end_date = new Date(Date.UTC(currentYear, currentMonth + 1, 0));
-                    while (current_pay_date <= month_end_date && (!reimbInc.end_date || current_pay_date <= new Date(reimbInc.end_date))) {
-                        if (current_pay_date >= month_start_date) {
-                            paydays_in_month++;
-                        }
-                        current_pay_date = addWeeks(current_pay_date, 2);
-                    }
-                    amountToReimburse = reimbInc.net_monthly * paydays_in_month;
-                }
-
-                // Allow negative values to reflect reimbursements exceeding expenses
-                if (reimbInc.reimbursement_category) {
-                    const currentExp = expensesThisMonth[reimbInc.reimbursement_category] || 0;
-                    expensesThisMonth[reimbInc.reimbursement_category] = currentExp - amountToReimburse;
-                }
-            }
-        });
-
+        const viewDate = currentBudgetViewDate instanceof Date ? currentBudgetViewDate : new Date();
+        const analysisStart = new Date(Date.UTC(viewDate.getUTCFullYear(), viewDate.getUTCMonth(), 1));
+        const tempCalcData = {
+            ...currentBackupData,
+            analysis_start_date: analysisStart,
+            analysis_duration: 1,
+            analysis_periodicity: 'Mensual',
+            incomes: (currentBackupData.incomes || []).map(inc => ({
+                ...inc,
+                start_date: inc.start_date ? new Date(inc.start_date) : null,
+                end_date: inc.end_date ? new Date(inc.end_date) : null
+            })),
+            expenses: (currentBackupData.expenses || []).map(exp => ({
+                ...exp,
+                start_date: exp.start_date ? new Date(exp.start_date) : null,
+                end_date: exp.end_date ? new Date(exp.end_date) : null,
+                movement_date: exp.movement_date ? new Date(exp.movement_date) : null
+            }))
+        };
+        const { expenses_by_cat_p } = calculateCashFlowData(tempCalcData);
+        const expensesThisMonth = expenses_by_cat_p[0] || {};
 
         const sortedCategories = Object.keys(currentBackupData.expense_categories).sort();
         sortedCategories.forEach(catName => {
@@ -2169,10 +2144,62 @@ document.addEventListener('DOMContentLoaded', () => {
             row.insertCell().textContent = formatCurrencyJS(spent, currentBackupData.display_currency_symbol);
             const diffCell = row.insertCell(); diffCell.textContent = formatCurrencyJS(difference, currentBackupData.display_currency_symbol);
             diffCell.classList.toggle('text-red', difference < 0); diffCell.classList.toggle('text-green', difference > 0 && budget > 0);
-            const percCell = row.insertCell(); percCell.textContent = `${percentageSpent.toFixed(1)}%`;
-            if (budget > 0) { if (percentageSpent > 100) percCell.classList.add('text-red'); else if (percentageSpent >= 80) percCell.classList.add('text-orange'); else percCell.classList.add('text-green'); }
+        const percCell = row.insertCell(); percCell.textContent = `${percentageSpent.toFixed(1)}%`;
+        if (budget > 0) { if (percentageSpent > 100) percCell.classList.add('text-red'); else if (percentageSpent >= 80) percCell.classList.add('text-orange'); else percCell.classList.add('text-green'); }
+    });
+    }
+
+    function setupBudgetPeriodSelectors() {
+        const today = new Date();
+        const analysisStartDate = (currentBackupData && currentBackupData.analysis_start_date)
+            ? new Date(currentBackupData.analysis_start_date)
+            : new Date(today);
+        currentBudgetViewDate = today;
+        const analysisEndDate = addMonths(new Date(analysisStartDate), (currentBackupData ? currentBackupData.analysis_duration : 12));
+        if (budgetYearSelect) {
+            budgetYearSelect.innerHTML = '';
+            const startYear = Math.min(analysisStartDate.getUTCFullYear(), new Date().getUTCFullYear()) - 2;
+            const endYear = Math.max(analysisEndDate.getUTCFullYear(), new Date().getUTCFullYear()) + 5;
+            for (let y = startYear; y <= endYear; y++) {
+                const option = document.createElement('option');
+                option.value = y; option.textContent = y; budgetYearSelect.appendChild(option);
+            }
+            budgetYearSelect.value = currentBudgetViewDate.getUTCFullYear();
+        }
+        if (budgetMonthSelect) {
+            budgetMonthSelect.innerHTML = '';
+            MONTH_NAMES_FULL_ES.forEach((monthName, index) => {
+                const option = document.createElement('option');
+                option.value = index; option.textContent = monthName; budgetMonthSelect.appendChild(option);
+            });
+            budgetMonthSelect.value = currentBudgetViewDate.getUTCMonth();
+        }
+        [budgetYearSelect, budgetMonthSelect].forEach(sel => {
+            if (!sel) return;
+            sel.removeEventListener('change', renderBudgetSummaryTableForSelectedPeriod);
+            sel.addEventListener('change', renderBudgetSummaryTableForSelectedPeriod);
         });
     }
+
+    function navigateBudgetPeriod(direction) {
+        let year = parseInt(budgetYearSelect.value);
+        let month = parseInt(budgetMonthSelect.value);
+        const newDate = new Date(Date.UTC(year, month, 15));
+        newDate.setUTCMonth(newDate.getUTCMonth() + direction);
+        budgetYearSelect.value = newDate.getUTCFullYear();
+        budgetMonthSelect.value = newDate.getUTCMonth();
+        renderBudgetSummaryTableForSelectedPeriod();
+    }
+
+    function renderBudgetSummaryTableForSelectedPeriod() {
+        const year = parseInt(budgetYearSelect.value);
+        const monthIndex = parseInt(budgetMonthSelect.value);
+        currentBudgetViewDate = new Date(Date.UTC(year, monthIndex, 1));
+        renderBudgetSummaryTable();
+    }
+
+    if (budgetPrevPeriodButton) budgetPrevPeriodButton.addEventListener('click', () => navigateBudgetPeriod(-1));
+    if (budgetNextPeriodButton) budgetNextPeriodButton.addEventListener('click', () => navigateBudgetPeriod(1));
 
     // --- LÓGICA PESTAÑA REGISTRO PAGOS ---
     function setupPaymentPeriodSelectors() {
@@ -2427,7 +2454,7 @@ document.addEventListener('DOMContentLoaded', () => {
             renderCashflowChart(periodDates, income_p, fixed_exp_p.map((val, idx) => val + var_exp_p[idx]), net_flow_p, end_bal_p);
         }
 
-        renderBudgetSummaryTable();
+        renderBudgetSummaryTableForSelectedPeriod();
     }
 
     function calculateCashFlowData(data) {

--- a/index.html
+++ b/index.html
@@ -292,6 +292,12 @@
                             </table>
                         </div>
                          <h3>Resumen Gasto vs Presupuesto (Mes Actual/Seleccionado)</h3>
+                        <div class="budget-period-selector">
+                            <button id="budget-prev-period-button" title="Mes Anterior">&lt;</button>
+                            <select id="budget-year-select"></select>
+                            <select id="budget-month-select"></select>
+                            <button id="budget-next-period-button" title="Mes Siguiente">&gt;</button>
+                        </div>
                         <div class="table-responsive dynamic-table-scroll" id="budget-summary-table-container">
                             <table id="budget-summary-table">
                                 <thead>

--- a/style.css
+++ b/style.css
@@ -674,6 +674,19 @@ td.reimbursement-income {
     margin-bottom: 0;
 }
 
+/* Estilos para Selección de Mes en Presupuestos */
+.budget-period-selector {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    margin: 10px 0;
+}
+.budget-period-selector select, .budget-period-selector button {
+    padding: 8px 10px;
+    margin-bottom: 0;
+}
+
 /* Selector de período para gráficos adicionales */
 .chart-period-selector {
     display: flex;
@@ -1100,6 +1113,17 @@ td.reimbursement-income {
       margin-bottom: 8px;
   }
   .payments-period-selector button {
+      flex-basis: auto;
+  }
+  .budget-period-selector {
+      flex-wrap: wrap;
+      justify-content: space-around;
+  }
+  .budget-period-selector select, .budget-period-selector button {
+      flex-basis: 45%;
+      margin-bottom: 8px;
+  }
+  .budget-period-selector button {
       flex-basis: auto;
   }
   .reminders-columns {


### PR DESCRIPTION
## Summary
- read monthly totals from cash flow when rendering budget summary

## Testing
- `node test_app_logic.js`


------
https://chatgpt.com/codex/tasks/task_e_687a634585e48320a2d1e6f5e5ee2c36