### PR TITLE
Default credit card payment and preferred card selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,14 +210,14 @@
                             </div>
 
                             <div class="checkbox-container">
-                                <input type="checkbox" id="expense-is-real">
+                                <input type="checkbox" id="expense-is-real" checked>
                                 <label for="expense-is-real">Es un gasto real (ya ocurrido)</label>
                             </div>
 
                             <label for="expense-payment-method">Método de Pago:</label>
                             <select id="expense-payment-method">
-                                <option value="Efectivo" selected>Efectivo</option>
-                                <option value="Credito">Tarjeta de Crédito</option>
+                                <option value="Efectivo">Efectivo</option>
+                                <option value="Credito" selected>Tarjeta de Crédito</option>
                             </select>
                             <div id="expense-credit-card-container" style="display:none;">
                                 <label for="expense-credit-card">Tarjeta:</label>


### PR DESCRIPTION
## Summary
- Default expenses to "gasto real" and credit card payment
- Allow marking a preferred credit card and preselect it in new expenses

## Testing
- `node test_app_logic.js`


------
https://chatgpt.com/codex/tasks/task_e_688cf60d70188320bc61fa9d62bb491f