### PR TITLE
Add USD/CLP multi-currency support with daily exchange rates

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,6 +110,12 @@
                             <label for="income-amount">Monto Neto:</label>
                             <input type="number" id="income-amount" step="any" required>
 
+                            <label for="income-currency">Moneda:</label>
+                            <select id="income-currency">
+                                <option value="USD" selected>USD</option>
+                                <option value="CLP">CLP</option>
+                            </select>
+
                             <label for="income-frequency">Frecuencia:</label>
                             <select id="income-frequency">
                                 <option value="Mensual">Mensual</option>
@@ -152,6 +158,7 @@
                                     <tr>
                                         <th>Nombre</th>
                                         <th>Monto</th>
+                                        <th>Moneda</th>
                                         <th>Frecuencia</th>
                                         <th>Inicio</th>
                                         <th>Fin</th>
@@ -178,6 +185,12 @@
 
                             <label for="expense-amount">Monto:</label>
                             <input type="number" id="expense-amount" step="any" required>
+
+                            <label for="expense-currency">Moneda:</label>
+                            <select id="expense-currency">
+                                <option value="USD" selected>USD</option>
+                                <option value="CLP">CLP</option>
+                            </select>
 
                             <label for="expense-category">Categoría:</label>
                             <div class="category-input-group">


### PR DESCRIPTION
## Summary
- add currency selectors for income and expense capture plus display currency in the data tables
- cache daily USD/CLP rates from Coinbase and convert CLP movements to USD per occurrence inside the cash-flow engine
- refresh payment tracking and summaries using the converted figures and auto-recalculate once new rates arrive

## Testing
- node test_app_logic.js

------
https://chatgpt.com/codex/tasks/task_e_68dae94193188320b4e7f0fd891e8b08