### PR TITLE
Add multi-currency handling and CLP to USD conversions

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,6 +110,12 @@
                             <label for="income-amount">Monto Neto:</label>
                             <input type="number" id="income-amount" step="any" required>
 
+                            <label for="income-currency">Moneda:</label>
+                            <select id="income-currency">
+                                <option value="USD" selected>USD</option>
+                                <option value="CLP">CLP</option>
+                            </select>
+
                             <label for="income-frequency">Frecuencia:</label>
                             <select id="income-frequency">
                                 <option value="Mensual">Mensual</option>
@@ -178,6 +184,12 @@
 
                             <label for="expense-amount">Monto:</label>
                             <input type="number" id="expense-amount" step="any" required>
+
+                            <label for="expense-currency">Moneda:</label>
+                            <select id="expense-currency">
+                                <option value="USD" selected>USD</option>
+                                <option value="CLP">CLP</option>
+                            </select>
 
                             <label for="expense-category">Categoría:</label>
                             <div class="category-input-group">


### PR DESCRIPTION
## Summary
- add currency selectors for income and expense entries and persist each record's currency
- implement USD/CLP rate caching with exchangerate.host and convert CLP transactions to USD per-occurrence across cashflow, payments, and charts
- surface original currency information in breakdowns and modals while keeping base calculations in USD

## Testing
- node test_app_logic.js

------
https://chatgpt.com/codex/tasks/task_e_68dae94193188320b4e7f0fd891e8b08