### PR TITLE
Add multi-currency conversion with daily USD/CLP rates

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,8 +107,14 @@
                             <label for="income-name">Nombre:</label>
                             <input type="text" id="income-name" required>
 
-                            <label for="income-amount">Monto Neto:</label>
-                            <input type="number" id="income-amount" step="any" required>
+                        <label for="income-amount">Monto Neto:</label>
+                        <input type="number" id="income-amount" step="any" required>
+
+                        <label for="income-currency">Moneda:</label>
+                        <select id="income-currency">
+                            <option value="USD" selected>USD - Dólar Estadounidense</option>
+                            <option value="CLP">CLP - Peso Chileno</option>
+                        </select>
 
                             <label for="income-frequency">Frecuencia:</label>
                             <select id="income-frequency">
@@ -178,6 +184,12 @@
 
                             <label for="expense-amount">Monto:</label>
                             <input type="number" id="expense-amount" step="any" required>
+
+                            <label for="expense-currency">Moneda:</label>
+                            <select id="expense-currency">
+                                <option value="USD" selected>USD - Dólar Estadounidense</option>
+                                <option value="CLP">CLP - Peso Chileno</option>
+                            </select>
 
                             <label for="expense-category">Categoría:</label>
                             <div class="category-input-group">


### PR DESCRIPTION
## Summary
- add currency selectors to income and expense forms so entries track USD or CLP
- introduce USD/CLP rate caching utilities and fetch daily rates to convert CLP amounts per occurrence when rendering cash flow data
- update tables, charts, and helpers to display per-item currency and work with converted USD totals

## Testing
- node test_app_logic.js

------
https://chatgpt.com/codex/tasks/task_e_68dae94193188320b4e7f0fd891e8b08