### PR TITLE
Add local backup management with diff-aware import

### DIFF
--- a/index.html
+++ b/index.html
@@ -488,6 +488,11 @@
             <div class="save-changes-container">
                  <button id="save-changes-button" class="accent">Guardar Nueva Versión</button>
             </div>
+            <div class="local-backup-container">
+                <button id="download-local-backup-button">Descargar copia local</button>
+                <button id="import-local-backup-button">Cargar copia local</button>
+                <input type="file" id="local-backup-file-input" accept="application/json" style="display:none;">
+            </div>
             <div id="chart-modal" class="modal" style="display:none;">
                 <div class="modal-content">
                     <span id="chart-modal-close" class="modal-close">&times;</span>

--- a/style.css
+++ b/style.css
@@ -661,6 +661,21 @@ td.reimbursement-income {
     font-size: 1.05rem;
 }
 
+.local-backup-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    justify-content: center;
+    margin-bottom: 2rem;
+}
+
+.local-backup-container button {
+    flex: 1 1 220px;
+    padding: 0.75rem 1.5rem;
+    font-size: 1rem;
+    cursor: pointer;
+}
+
 /* Estilos específicos para Pestaña Ajustes */
 .settings-form-container {
     max-width: 600px;


### PR DESCRIPTION
## Summary
- add UI controls that let users download and import local backup files
- implement helper utilities to serialize, hydrate, and warn about differences before restoring backups
- style the backup action buttons to match existing save controls

## Testing
- node WebAPP_Chile/test_app_logic.js

------
https://chatgpt.com/codex/tasks/task_e_68e5cce67c2c83208db221c194bb91a3